### PR TITLE
remove training, cache pair scores

### DIFF
--- a/lr_face/data_providers.py
+++ b/lr_face/data_providers.py
@@ -94,7 +94,7 @@ def enfsi_data(resolution, year) -> PairsWithIds:
             elif questioned_ref=='r':
                 X[cls-1][1]=img
             else:
-                raise ValueError(f'unknown questioned/ref: {questioned_red}')
+                raise ValueError(f'unknown questioned/ref: {questioned_ref}')
     return PairsWithIds(pairs=X, is_same_source=y, pair_ids=ids)
 
 
@@ -135,9 +135,8 @@ def combine_paired_data(pair_providers: List[PairProvider], resolution) -> Pairs
 
 def get_data(datasets: DataFunctions, resolution=(100, 100), fraction_test=0.2, **kwargs) -> ImagePairs:
     """
-    Takes a function that returns X, y, with X either images or pairs of images and y identities. Returns a dataset with all data
-    split into the right datasets
-
+    Takes a function that can returns both pairs of images or unpaired images (with person identities).
+    Returns a dataset with all data combined into pairs and split into the right datasets
 
     """
     X_calibrate = []

--- a/lr_face/evaluators.py
+++ b/lr_face/evaluators.py
@@ -2,11 +2,11 @@ from typing import Dict
 
 import matplotlib.pyplot as plt
 import numpy as np
-from lir import Xy_to_Xn, calculate_cllr, CalibratedScorer, ELUBbounder
+from lir import Xy_to_Xn, calculate_cllr, CalibratedScorer, ELUBbounder, plot_score_distribution_and_calibrator_fit
 from sklearn.metrics import accuracy_score, roc_auc_score
 
 # from lir.plotting import plot_calibration, plot_lr_distributions
-from lr_face.data_providers import make_pairs, Images
+from lr_face.data_providers import make_pairs, ImagePairs
 
 
 def plot_lr_distributions(predicted_log_lrs, y, savefig=None, show=None):
@@ -18,30 +18,6 @@ def plot_lr_distributions(predicted_log_lrs, y, savefig=None, show=None):
     plt.hist(points0, bins=20, alpha=.25, density=True)
     plt.hist(points1, bins=20, alpha=.25, density=True)
     plt.xlabel('10log LR')
-    if savefig is not None:
-        plt.savefig(savefig)
-        plt.close()
-    if show or savefig is None:
-        plt.show()
-
-
-def plot_calibration(lr_system: CalibratedScorer, scores, y, savefig=None, show=None):
-    """
-    plots the distributions of scores calculated by the (fitted) lr_system, as well as the fitted score distributions/
-    score-to-posterior map
-    """
-    plt.figure(figsize=(10, 10), dpi=100)
-    x = np.arange(0, 1, .01)
-    lr_system.calibrator.transform(x)
-    points0, points1 = Xy_to_Xn(scores, y)
-    plt.hist(points0, bins=20, alpha=.25, density=True, label='class 0')
-    plt.hist(points1, bins=20, alpha=.25, density=True, label='class 1')
-    if type(lr_system.calibrator) == ELUBbounder:
-        plt.plot(x, lr_system.calibrator.first_step_calibrator.p1, label='fit class 1')
-        plt.plot(x, lr_system.calibrator.first_step_calibrator.p0, label='fit class 0')
-    else:
-        plt.plot(x, lr_system.calibrator.p1, label='fit class 1')
-        plt.plot(x, lr_system.calibrator.p0, label='fit class 0')
     if savefig is not None:
         plt.savefig(savefig)
         plt.close()
@@ -63,20 +39,22 @@ def calculate_metrics_dict(scores, y, lr_predicted, label):
             }
 
 
-def evaluate(lr_system: CalibratedScorer, data_provider: Images, make_plots_and_save_as=None) -> Dict[str, float]:
+def evaluate(lr_system: CalibratedScorer, data_provider: ImagePairs, make_plots_and_save_as=None) -> Dict[str, float]:
     """
     Calculates a variety of evaluation metrics and plots data if make_plots_and_save_as is not None
 
     """
-    X_test, y_test = make_pairs(data_provider.X_test, data_provider.y_test)
-    LR_predicted = lr_system.predict_lr(X_test)
-    scores = lr_system.scorer.predict_proba(X_test)[:, 1]
+    scores = lr_system.scorer.predict_proba(data_provider.X_test, data_provider.ids_test)[:, 1]
+    LR_predicted = lr_system.calibrator.transform(scores)
 
     if make_plots_and_save_as:
-        plot_calibration(lr_system, scores=scores, y=y_test, savefig=f'{make_plots_and_save_as} calibration.png')
-        plot_lr_distributions(np.log10(LR_predicted), y_test, savefig=f'{make_plots_and_save_as} lr distribution.png')
+        calibrator = lr_system.calibrator
+        if type(calibrator) == ELUBbounder:
+            calibrator = calibrator.first_step_calibrator
+        plot_score_distribution_and_calibrator_fit(calibrator, scores, data_provider.y_test, savefig=f'{make_plots_and_save_as} calibration.png')
+        plot_lr_distributions(np.log10(LR_predicted),data_provider.y_test,savefig=f'{make_plots_and_save_as} lr distribution.png')
 
 
-    metric_dict = calculate_metrics_dict(scores, y_test, LR_predicted, '')
+    metric_dict = calculate_metrics_dict(scores, data_provider.y_test, LR_predicted, '')
 
     return metric_dict

--- a/lr_face/models.py
+++ b/lr_face/models.py
@@ -23,6 +23,9 @@ class DummyModel:
         assert len(X[0]) == 2, f'should get n pairs, but second dimension is {X.shape[1]}'
         return np.random.random((len(X), 2))
 
+    def __str__(self):
+        return 'Dummy'
+
 
 class Deepface_Lib_Model:
     """

--- a/lr_face/models.py
+++ b/lr_face/models.py
@@ -1,4 +1,6 @@
+import time
 import numpy as np
+import functools
 
 from scipy import spatial
 from lr_face.utils import resize_and_normalize
@@ -16,9 +18,9 @@ class DummyModel:
         assert X.shape[1:3] == self.resolution
         pass
 
-    def predict_proba(self, X):
+    def predict_proba(self, X, ids=None):
         # assert X.shape[2:4] == self.resolution
-        assert X.shape[1] == 2, f'should get n pairs, but second dimension is {X.shape[1]}'
+        assert len(X[0]) == 2, f'should get n pairs, but second dimension is {X.shape[1]}'
         return np.random.random((len(X), 2))
 
 
@@ -29,17 +31,25 @@ class Deepface_Lib_Model:
 
     def __init__(self, model):
         self.model = model
+        self.cache = {}
 
-    def predict_proba(self, X):
+    def predict_proba(self, X, ids):
+        assert len(X)==len(ids)
         scores = []
-        for pair in X:
-            img1 = resize_and_normalize(pair[0], self.model.input_shape[1:3])
-            img2 = resize_and_normalize(pair[1], self.model.input_shape[1:3])
-
-            img1_representation = self.model.predict(img1)[0, :]
-            img2_representation = self.model.predict(img2)[0, :]
-
-            score = spatial.distance.cosine(img1_representation, img2_representation)
+        for id, pair in zip(ids, X):
+            if id in self.cache:
+                score = self.cache[id]
+            else:
+                score = self.score_for_pair(pair)
+                self.cache[id]=score
             scores.append([score, 1-score])
 
         return np.asarray(scores)
+
+    def score_for_pair(self, pair):
+        img1 = resize_and_normalize(pair[0], self.model.input_shape[1:3])
+        img2 = resize_and_normalize(pair[1], self.model.input_shape[1:3])
+        img1_representation = self.model.predict(img1)[0, :]
+        img2_representation = self.model.predict(img2)[0, :]
+        score = spatial.distance.cosine(img1_representation, img2_representation)
+        return score

--- a/params.py
+++ b/params.py
@@ -7,7 +7,7 @@ from lir import LogitCalibrator, NormalizedCalibrator, ELUBbounder, KDECalibrato
 
 from deepface.deepface.basemodels import VGGFace, FbDeepFace, Facenet, OpenFace
 from lr_face.models import DummyModel, Deepface_Lib_Model
-from lr_face.data_providers import test_data, enfsi_data, combine_data
+from lr_face.data_providers import test_data, enfsi_data, combine_pairs
 
 
 """How often to repeat all experiments"""
@@ -20,7 +20,7 @@ For the input of an experiment the 'current_set_up' list can be updated
 """
 PARAMS = {
 
-    'current_set_up': ['calibrate_same1'],
+    'current_set_up': ['SET1'],
     'all': {
         'SET1': {
             'fraction_training': 0.6,
@@ -59,11 +59,12 @@ DATA = {
         },
         'enfsi': {
             #TODO currently every element becomes a new experiment, we probably want functionality to combine datasets
-            'dataset_callable': partial(combine_data, dataset_callables=[partial(enfsi_data, year=2011),
+            'dataset_callable': partial(combine_pairs, dataset_callables=[partial(enfsi_data, year=2011),
                                  partial(enfsi_data, year=2012),
                                  partial(enfsi_data, year=2013),
-                                 partial(enfsi_data, year=2017)]),
-            'fraction_test': .5,
+                                 partial(enfsi_data, year=2017)
+                                                                          ]),
+            'fraction_test': .2,
         }
     }
 }
@@ -73,7 +74,7 @@ New models/scorers can be added to 'all'.
 For the input of an experiment the 'current_set_up' list can be updated
 """
 SCORERS = {
-    'current_set_up': ['openface', 'vggface', 'dummy'],
+    'current_set_up': ['openface', 'facenet', 'vggface','fbdeepface','dummy'],
     'all': {
         'dummy': DummyModel(),
         'openface': Deepface_Lib_Model(model=OpenFace.loadModel()),
@@ -88,7 +89,7 @@ New calibrators can be added to 'all'.
 For the input of an experiment the 'current_set_up' list can be updated
 """
 CALIBRATORS = {
-    'current_set_up': ['elub_KDE'],
+    'current_set_up': ['KDE'],
     'all': {
         'logit': LogitCalibrator(),
         'logit_normalized': NormalizedCalibrator(LogitCalibrator()),

--- a/params.py
+++ b/params.py
@@ -7,7 +7,7 @@ from lir import LogitCalibrator, NormalizedCalibrator, ELUBbounder, KDECalibrato
 
 from deepface.deepface.basemodels import VGGFace, FbDeepFace, Facenet, OpenFace
 from lr_face.models import DummyModel, Deepface_Lib_Model
-from lr_face.data_providers import test_data, enfsi_data, combine_pairs
+from lr_face.data_providers import test_data, enfsi_data, combine_paired_data, DataFunctions
 
 
 """How often to repeat all experiments"""
@@ -54,16 +54,16 @@ DATA = {
     'current_set_up': ['enfsi'],
     'all': {
         'test': {
-            'dataset_callable': [test_data],
+            'datasets': [DataFunctions(image_provider=test_data, pair_provider=None)],
             'fraction_test': .5,
         },
         'enfsi': {
-            #TODO currently every element becomes a new experiment, we probably want functionality to combine datasets
-            'dataset_callable': partial(combine_pairs, dataset_callables=[partial(enfsi_data, year=2011),
+            'datasets': [DataFunctions(image_provider=None,
+                                       pair_provider=partial(combine_paired_data, pair_providers=[partial(enfsi_data, year=2011),
                                  partial(enfsi_data, year=2012),
                                  partial(enfsi_data, year=2013),
                                  partial(enfsi_data, year=2017)
-                                                                          ]),
+                                                                          ]))],
             'fraction_test': .2,
         }
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib
 scipy
 keras
 opencv-python
+typing-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 sklearn
 numpy
 streamlit
-lir
+lir>=0.0.3
 tqdm
 confidence
 pandas

--- a/run.py
+++ b/run.py
@@ -36,12 +36,10 @@ def run(args):
     n_experiments = experiments_setup.data_frame.shape[0]
     for row in tqdm(range(0, n_experiments)):
         params_dict = experiments_setup.data_frame[parameters_used].iloc[row].to_dict()
-        if (params_dict['dataset_callable'], params_dict['fraction_test']) not in dataproviders:
-            dataproviders[(params_dict['dataset_callable'], params_dict['fraction_test'])] = get_data(
-                dataset_callable=params_dict['dataset_callable'],
-                            fraction_test=params_dict['fraction_test'],
-            )
-        data_provider = dataproviders[(params_dict['dataset_callable'], params_dict['fraction_test'])]
+        data_params = (str(params_dict['datasets']), params_dict['fraction_test'])
+        if data_params not in dataproviders:
+            dataproviders[data_params] = get_data(**params_dict)
+        data_provider = dataproviders[data_params]
 
         if row < n_experiments / TIMES:
             # for the first round, make plots

--- a/run.py
+++ b/run.py
@@ -8,7 +8,7 @@ from lir import CalibratedScorer
 from lir.util import to_odds
 from tqdm import tqdm
 
-from lr_face.data_providers import get_data, make_pairs, ImagePairs
+from lr_face.data_providers import get_data, ImagePairs
 from lr_face.evaluators import evaluate
 from lr_face.experiment_settings import ExperimentSettings
 from lr_face.utils import write_output, parser_setup, process_dataframe

--- a/run_data_exploration.py
+++ b/run_data_exploration.py
@@ -32,7 +32,7 @@ if research_question == 'train_calibrate_same_data':
     for metric in ('cllr', 'auc', 'accuracy'):
 
         st.altair_chart(alt.Chart(df).mark_boxplot().encode(
-            x='dataset_callable',
+            x='scorers',
             y=alt.Y(metric,
                     scale=alt.Scale(domain=[0, 1.2])
                     ),


### PR DESCRIPTION
alle verwijzingingen naar training data zouden er nu uit moeten zijn
de scorer cached scores voor paren adhv een id dat meegegeven wordt. dit werkt goed voor de enfsi data, en voor onze opzet waarbij telkens dezelfde paren bekeken worden in verschillende experimenten. op zich is voor images de vector cachen wellicht logischer, maar daar kunnen we dan over nadenken. Ik laad nu ook alleen de paren voor enfsi, niet alle combinaties, omdat dat meer klopt met zaakscontext, en beter vergelijkbaar is met expert uitslagen