### PR TITLE
Feature/use embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 /build
 /dist
 /.idea
+/embeddings
 /results
 /output
 /scratch

--- a/lr_face/data.py
+++ b/lr_face/data.py
@@ -283,8 +283,7 @@ class Dataset:
         return hash(str(self))
 
     def __eq__(self, other) -> bool:
-        return isinstance(other, self.__class__) \
-               and set(self.images) == set(other.images)
+        return isinstance(other, self.__class__) and str(self) == str(other)
 
     def __str__(self) -> str:
         return self.__class__.__name__
@@ -693,9 +692,13 @@ def split_pairs(
 ) -> Tuple[List[FacePair], List[FacePair]]:
     """
     Takes a single collection of pairs and splits them in two separate sets in
-    such a way that `(1 - fraction_test)` of the identities are put in the
-    first set and the remaining `fraction_test` of the identities in the
-    second. An optional `random_state` can be specified to make the resulting
+    such a way that `(1 - fraction_test)` of the unique paired identities end
+    up in the first set and the remaining `fraction_test` of the unique pair
+    identities end up in the second. A pair identity is defined as the
+    combination of the two individual identities contained in a pair. When
+    determining uniqueness, their ordering inside the pair does not matter.
+
+    An optional `random_state` can be specified to make the resulting
     split deterministic.
 
     :param pairs: List[FacePair]
@@ -704,10 +707,9 @@ def split_pairs(
     :return: Tuple[List[FacePair], List[FacePair]]
     """
 
-    gss = GroupShuffleSplit(
-        n_splits=1, test_size=fraction_test, random_state=random_state)
-
-    # TODO: are the group ids unique enough?
+    gss = GroupShuffleSplit(n_splits=1,
+                            test_size=fraction_test,
+                            random_state=random_state)
     groups = ['|'.join(sorted(x.identity for x in pair)) for pair in pairs]
     train_idx, test_idx = next(gss.split(pairs, groups=groups))
     return [pairs[idx] for idx in train_idx], [pairs[idx] for idx in test_idx]

--- a/lr_face/data.py
+++ b/lr_face/data.py
@@ -66,10 +66,15 @@ class FaceImage:
         Depending on the architecture, the dimensionality of the embedding may
         differ. Returns a 1D array of shape `(embedding_size)`.
 
-        TODO: implement.
-        TODO: implement hashing in `Architecture`, otherwise caching doesn't work.
+        :param architecture: Architecture
+        :return: np.ndarray
         """
-        raise NotImplementedError
+        image = self.get_image(architecture.resolution, normalize=True)
+        x = np.expand_dims(image, axis=0)
+        embedding_model = architecture.get_embedding_model()
+        embedding = embedding_model.predict(x)[0]
+        # TODO: store the embedding on the filesystem?
+        return embedding
 
     def __post_init__(self):
         if not self.meta:

--- a/lr_face/evaluators.py
+++ b/lr_face/evaluators.py
@@ -29,15 +29,18 @@ def plot_tippett(predicted_log_lrs, y, savefig=None, show=None):
     """
     Plots the 10log LRs in a Tippett plot.
     """
-    xplot = np.linspace(np.min(predicted_log_lrs), np.max(predicted_log_lrs),
-                        100)
+    xplot = np.linspace(
+        start=np.min(predicted_log_lrs),
+        stop=np.max(predicted_log_lrs),
+        num=100
+    )
     lr_0, lr_1 = Xy_to_Xn(predicted_log_lrs, y)
     perc0 = (sum(i > xplot for i in lr_0) / len(lr_0)) * 100
     perc1 = (sum(i > xplot for i in lr_1) / len(lr_1)) * 100
 
     plt.figure(figsize=(10, 10), dpi=100)
-    plt.plot(xplot, perc1, color='b', label='LRs given $\mathregular{H_1}$')
-    plt.plot(xplot, perc0, color='r', label='LRs given $\mathregular{H_2}$')
+    plt.plot(xplot, perc1, color='b', label=r'LRs given $\mathregular{H_1}$')
+    plt.plot(xplot, perc0, color='r', label=r'LRs given $\mathregular{H_2}$')
     plt.axvline(x=0, color='k', linestyle='--')
     plt.xlabel('Log likelihood ratio')
     plt.ylabel('Cumulative proportion')
@@ -65,7 +68,8 @@ def evaluate(lr_system: CalibratedScorer,
              test_pairs: List[FacePair],
              make_plots_and_save_as: Optional[str] = None) -> Dict[str, float]:
     """
-    Calculates a variety of evaluation metrics and plots data if make_plots_and_save_as is not None.
+    Calculates a variety of evaluation metrics and plots data if
+    `make_plots_and_save_as` is not None.
     """
     scores = lr_system.scorer.predict_proba(test_pairs)[:, 1]
     lr_predicted = lr_system.calibrator.transform(scores)

--- a/lr_face/evaluators.py
+++ b/lr_face/evaluators.py
@@ -5,8 +5,6 @@ import numpy as np
 from lir import Xy_to_Xn, calculate_cllr, CalibratedScorer, ELUBbounder, plot_score_distribution_and_calibrator_fit
 from sklearn.metrics import accuracy_score, roc_auc_score
 
-from lr_face.data_providers import ImagePairs
-
 
 def plot_lr_distributions(predicted_log_lrs, y, savefig=None, show=None):
     """

--- a/lr_face/evaluators.py
+++ b/lr_face/evaluators.py
@@ -1,9 +1,12 @@
-from typing import Dict
+from typing import Dict, Optional, List
 
 import matplotlib.pyplot as plt
 import numpy as np
-from lir import Xy_to_Xn, calculate_cllr, CalibratedScorer, ELUBbounder, plot_score_distribution_and_calibrator_fit
+from lir import Xy_to_Xn, calculate_cllr, CalibratedScorer, ELUBbounder, \
+    plot_score_distribution_and_calibrator_fit
 from sklearn.metrics import accuracy_score, roc_auc_score
+
+from lr_face.data import FacePair
 
 
 def plot_lr_distributions(predicted_log_lrs, y, savefig=None, show=None):
@@ -26,7 +29,8 @@ def plot_tippett(predicted_log_lrs, y, savefig=None, show=None):
     """
     Plots the 10log LRs in a Tippett plot.
     """
-    xplot = np.linspace(np.min(predicted_log_lrs), np.max(predicted_log_lrs), 100)
+    xplot = np.linspace(np.min(predicted_log_lrs), np.max(predicted_log_lrs),
+                        100)
     lr_0, lr_1 = Xy_to_Xn(predicted_log_lrs, y)
     perc0 = (sum(i > xplot for i in lr_0) / len(lr_0)) * 100
     perc1 = (sum(i > xplot for i in lr_1) / len(lr_1)) * 100
@@ -54,27 +58,46 @@ def calculate_metrics_dict(scores, y, lr_predicted, label):
 
     return {'cllr' + label: round(calculate_cllr(X1, X2).cllr, 4),
             'auc' + label: roc_auc_score(y, scores),
-            'accuracy' + label: accuracy_score(y, scores > .5)
-            }
+            'accuracy' + label: accuracy_score(y, scores > .5)}
 
 
-def evaluate(lr_system: CalibratedScorer, data_provider: ImagePairs, make_plots_and_save_as=None) -> Dict[str, float]:
+def evaluate(lr_system: CalibratedScorer,
+             test_pairs: List[FacePair],
+             make_plots_and_save_as: Optional[str] = None) -> Dict[str, float]:
     """
     Calculates a variety of evaluation metrics and plots data if make_plots_and_save_as is not None.
     """
-    scores = lr_system.scorer.predict_proba(data_provider.X_test, data_provider.ids_test)[:, 1]
-    LR_predicted = lr_system.calibrator.transform(scores)
+    scores = lr_system.scorer.predict_proba(test_pairs)[:, 1]
+    lr_predicted = lr_system.calibrator.transform(scores)
+    y_test = [int(pair.same_identity) for pair in test_pairs]
 
     if make_plots_and_save_as:
         calibrator = lr_system.calibrator
         if type(calibrator) == ELUBbounder:
             calibrator = calibrator.first_step_calibrator
-        plot_score_distribution_and_calibrator_fit(calibrator, scores, data_provider.y_test,
-                                                   savefig=f'{make_plots_and_save_as} calibration.png')
-        plot_lr_distributions(np.log10(LR_predicted), data_provider.y_test,
-                              savefig=f'{make_plots_and_save_as} lr distribution.png')
-        plot_tippett(np.log10(LR_predicted), data_provider.y_test, savefig=f'{make_plots_and_save_as} tippett.png')
 
-    metric_dict = calculate_metrics_dict(scores, data_provider.y_test, LR_predicted, '')
+        plot_score_distribution_and_calibrator_fit(
+            calibrator,
+            scores,
+            y_test,
+            savefig=f'{make_plots_and_save_as} calibration.png'
+        )
 
-    return metric_dict
+        plot_lr_distributions(
+            np.log10(lr_predicted),
+            y_test,
+            savefig=f'{make_plots_and_save_as} lr distribution.png'
+        )
+
+        plot_tippett(
+            np.log10(lr_predicted),
+            y_test,
+            savefig=f'{make_plots_and_save_as} tippett.png'
+        )
+
+    return calculate_metrics_dict(
+        scores,
+        y_test,
+        lr_predicted,
+        label=''
+    )

--- a/lr_face/models.py
+++ b/lr_face/models.py
@@ -194,7 +194,7 @@ class Architecture(Enum):
     ```
     """
     VGGFACE = 'VGGFace'
-    FACENET = 'FaceNet'
+    FACENET = 'Facenet'
     FBDEEPFACE = 'FbDeepFace'
     OPENFACE = 'OpenFace'
 
@@ -223,6 +223,15 @@ class Architecture(Enum):
         :return: Tuple[int, int]
         """
         return self.get_embedding_model().input_shape[1:3]
+
+    @property
+    def embedding_size(self) -> int:
+        """
+        Returns the dimensionality of the embeddings for this architecture.
+
+        :return: int
+        """
+        return self.get_embedding_model().output_shape[1]
 
     @property
     def source(self) -> str:

--- a/params.py
+++ b/params.py
@@ -68,8 +68,11 @@ New models/scorers can be added to 'all'.
 For the input of an experiment the 'current_set_up' list can be updated.
 """
 SCORERS = {
-    'current_set_up': ['openface', 'facenet', 'vggface', 'fbdeepface',
-                       'dummy'],
+    'current_set_up': ['dummy',
+                       'openface',
+                       'facenet',
+                       'vggface',
+                       'fbdeepface'],
     'all': {
         'dummy': DummyScorerModel(),
         'openface': Architecture.OPENFACE.get_scorer_model(),

--- a/run.py
+++ b/run.py
@@ -8,7 +8,6 @@ from lir import CalibratedScorer
 from lir.util import to_odds
 from tqdm import tqdm
 
-from lr_face.data_providers import get_data, ImagePairs
 from lr_face.evaluators import evaluate
 from lr_face.experiment_settings import ExperimentSettings
 from lr_face.utils import write_output, parser_setup, process_dataframe

--- a/run.py
+++ b/run.py
@@ -1,72 +1,95 @@
 #!/usr/bin/env python3
 import os
 from datetime import datetime
+from typing import List, Optional, Dict
 
 import confidence
-import numpy as np
 from lir import CalibratedScorer
-from lir.util import to_odds
 from tqdm import tqdm
 
+from lr_face.data import split_pairs, FacePair
 from lr_face.evaluators import evaluate
 from lr_face.experiment_settings import ExperimentSettings
-from lr_face.utils import write_output, parser_setup, process_dataframe
+from lr_face.utils import write_output, parser_setup, process_dataframe, \
+    fix_tensorflow_rtx
 from params import TIMES
+
+fix_tensorflow_rtx()
 
 
 def run(args):
     """
     Run one or more calibration experiments.
-    The ExperimentSettings class generates a dataframe containing the different parameter combinations called in the
-    command line or in params.py.
+    The ExperimentSettings class generates a dataframe containing the different
+    parameter combinations called in the command line or in params.py.
     """
     experiments_setup = ExperimentSettings(args)
     parameters_used = experiments_setup.input_parameters  # exclude output columns
-
     experiment_name = datetime.now().strftime("%Y-%m-%d %H %M %S")
-
     plots_dir = os.path.join('output', experiment_name)
     if not os.path.exists(plots_dir):
         os.makedirs(plots_dir)
 
-    # caching for data
-    dataproviders = {}
-
+    data_splits = dict()
     n_experiments = experiments_setup.data_frame.shape[0]
-    for row in tqdm(range(0, n_experiments)):
-        params_dict = experiments_setup.data_frame[parameters_used].iloc[row].to_dict()
-        data_params = (str(params_dict['datasets']), params_dict['fraction_test'])
-        if data_params not in dataproviders:
-            dataproviders[data_params] = get_data(**params_dict)
-        data_provider = dataproviders[data_params]
+    for row in tqdm(range(n_experiments)):
+        params_dict = \
+            experiments_setup.data_frame[parameters_used].iloc[row].to_dict()
+        dataset = params_dict['datasets']
+        pairs = [pair for pair in dataset.pairs]
+        fraction_test = params_dict['fraction_test']
 
+        data_params = (dataset, fraction_test)
+        if data_params not in data_splits:
+            data_splits[data_params] = split_pairs(pairs, fraction_test)
+        calibration_pairs, test_pairs = data_splits[data_params]
+
+        make_plots_and_save_as = None
+        # For the first round, make plots
         if row < n_experiments / TIMES:
-            # for the first round, make plots
-            make_plots_and_save_as = os.path.join(plots_dir,
-                                                  f"{'_'.join([str(v)[:25] for v in params_dict.values()])}")
-            results = experiment(params_dict, data_provider=data_provider,
-                                 make_plots_and_save_as=make_plots_and_save_as)
-        else:
-            results = experiment(params_dict, data_provider=data_provider)
+            make_plots_and_save_as = os.path.join(
+                plots_dir,
+                f"{'_'.join([str(v)[:25] for v in params_dict.values()])}"
+            )
+
+        results = experiment(params_dict,
+                             calibration_pairs,
+                             test_pairs,
+                             make_plots_and_save_as)
 
         for k, v in results.items():
             experiments_setup.data_frame.loc[row, k] = v
 
-    experiments_setup.data_frame = process_dataframe(experiments_setup.data_frame)
+    experiments_setup.data_frame = \
+        process_dataframe(experiments_setup.data_frame)
     write_output(experiments_setup.data_frame, experiment_name)
 
 
-def experiment(params, data_provider: ImagePairs = None, make_plots_and_save_as=None):
+def experiment(
+        params,
+        calibration_pairs: List[FacePair],
+        test_pairs: List[FacePair],
+        make_plots_and_save_as: Optional[str] = None
+) -> Dict[str, float]:
     """
     Function to run a single experiment with pipeline:
-    DataProvider -> fit model on train data -> fit calibrator on calibrator data -> evaluate test set
+    - Fit model on train data
+    - Fit calibrator on calibrator data
+    - Evaluate test set
 
+    :param params: Dict
+    :param calibration_pairs: List[FacePair]
+    :param test_pairs: List[FacePair]
+    :param make_plots_and_save_as: str
+    :return: Dict[str, float]
     """
     lr_system = CalibratedScorer(params['scorers'], params['calibrators'])
-    p = lr_system.scorer.predict_proba(data_provider.X_calibrate, data_provider.ids_calibrate)
-    lr_system.calibrator.fit(p[:, 1], data_provider.y_calibrate)
-
-    return evaluate(lr_system, data_provider, make_plots_and_save_as)
+    p = lr_system.scorer.predict_proba(calibration_pairs)
+    lr_system.calibrator.fit(
+        X=p[:, 1],
+        y=[int(pair.same_identity) for pair in calibration_pairs]
+    )
+    return evaluate(lr_system, test_pairs, make_plots_and_save_as)
 
 
 if __name__ == '__main__':

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -39,3 +39,35 @@ def test_get_triplet_embedding_models():
     """
     for architecture in Architecture:
         architecture.get_triplet_embedding_model()
+
+
+def test_resolution_vggface():
+    assert Architecture.VGGFACE.resolution == (224, 224)
+
+
+def test_embedding_size_vggface():
+    assert Architecture.VGGFACE.embedding_size == 4096
+
+
+def test_resolution_openface():
+    assert Architecture.OPENFACE.resolution == (96, 96)
+
+
+def test_embedding_size_openface():
+    assert Architecture.OPENFACE.embedding_size == 128
+
+
+def test_resolution_fbdeepface():
+    assert Architecture.FBDEEPFACE.resolution == (152, 152)
+
+
+def test_embedding_size_fbdeepface():
+    assert Architecture.FBDEEPFACE.embedding_size == 4096
+
+
+def test_resolution_facenet():
+    assert Architecture.FACENET.resolution == (160, 160)
+
+
+def test_embedding_size_facenet():
+    assert Architecture.FACENET.embedding_size == 128

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+from typing import Tuple, Dict
+
 from lr_face.utils import cache
 
 
@@ -51,3 +54,77 @@ def test_cache_with_arguments():
     func(1.0, 2.0)  # Floats and ints are treated as the same arguments.
     assert func.cache_info().hits == 2
     assert func.cache_info().misses == 5
+
+
+def test_cache_with_class_methods():
+    class CacheTest:
+        """
+        Dummy class that can multiply two numbers and add a bias term. It keeps
+        track of the number of times `multiply` has been computed (not called!)
+        with a certain set of arguments. Since we cache the method, the counter
+        should initially be 0 and then be increased to 1 the first time it is
+        called. Subsequent calls should not increment the counter any further.
+        """
+        def __init__(self, bias):
+            self.counter: Dict[Tuple[float, float], int] = defaultdict(int)
+            self.bias = bias
+
+        @cache
+        def multiply(self, a: float, b: float):
+            self.counter[(a, b)] += 1
+            return a * b + self.bias
+
+        def __hash__(self):
+            return hash(self.bias)
+
+        def __eq__(self, other):
+            return self.bias == other.bias
+
+    # Create 3 instances of this dummy class.
+    # The first is unique in that it has a `bias` of 1.
+    instance1 = CacheTest(1)
+
+    # The second has a `bias` of 2, so it's different from `instance1`.
+    instance2 = CacheTest(2)
+
+    # The third also has a `bias` of 2, so its hash is the same as `instance2`.
+    instance3 = CacheTest(2)
+
+    # When we call `multiply` on the first instance we expect the counter to go
+    # from 0 to 1 for `instance1`, but remain 0 for `instance2`.
+    assert instance1.counter[(2, 3)] == 0
+    assert instance2.counter[(2, 3)] == 0
+    instance1.multiply(2, 3)
+    assert instance1.multiply.cache_info().hits == 0
+    assert instance1.counter[(2, 3)] == 1
+    assert instance2.counter[(2, 3)] == 0
+
+    # When we call `multiply` a second time, we should see no further changes
+    # in the counter.
+    instance1.multiply(2, 3)
+    assert instance1.counter[(2, 3)] == 1
+    assert instance2.counter[(2, 3)] == 0
+
+    # We should see a cache hit. The cache hits are apparently stored at the
+    # class-level, so all other instances of the same class will always have
+    # the same number of cache hits. This behavior is weird and so we should
+    # preferably not depend on this, since it's bound to introduce errors.
+    assert instance1.multiply.cache_info().hits == 1
+    assert instance2.multiply.cache_info().hits == 1
+    assert instance3.multiply.cache_info().hits == 1
+
+    # When we now call `multiply` on `instance2`, we expect its counter to be
+    # increased to 1, and subsequent calls should not affect it.
+    assert instance2.counter[(2, 3)] == 0
+    instance2.multiply(2, 3)
+    assert instance2.counter[(2, 3)] == 1
+    instance2.multiply(2, 3)
+    assert instance2.counter[(2, 3)] == 1
+
+    # Now, since `instance2` and `instance3` have the same hash, we expect that
+    # when we call `instance3.multiply` with the same arguments with which we
+    # previously called `instance2.multiply` the cached result is returned,
+    # thus the counter of `instance3` should NOT be incremented and remain 0.
+    assert instance3.counter[(2, 3)] == 0
+    instance3.multiply(2, 3)
+    assert instance3.counter[(2, 3)] == 0


### PR DESCRIPTION
* Refactored `run.py` and related files so that the main pipeline works with the new data structures.
* Added `get_embedding()` to the `FaceImage` dataclass, which allows you to get an image's embedding based on a specified `Architecture`. 
  - This method also supports optionally caching results to disk in addition to caching to memory. Caching to disk is helpful for reducing the time it takes to compute the embeddings the first time in a program's lifetime. After the embedding has been computed once within the same program, the memory caching mechanism takes over regardless of whether on-disk caching is used or not.
* Added a `split_pairs()` method to `data.py` which can split a list of `FacePair` instances into two separate lists where it is guaranteed that no paired identities occur in both sets. This can later be made more generic to split into any number of splits.
* Updated unit tests for the newly introduced methods.