### PR TITLE
Feature/versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__
 /dist
 /.idea
 /embeddings
+/models
 /results
 /output
 /scratch

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ __pycache__
 /dist
 /.idea
 /embeddings
-/models
+/weights
 /results
 /output
 /scratch

--- a/finetuning.py
+++ b/finetuning.py
@@ -1,76 +1,48 @@
 import argparse
-import os
-import time
+from typing import Optional
 
-import numpy as np
 from tensorflow.keras.optimizers import Adam
 
-from lr_face.data import EnfsiDataset, to_array
+from lr_face.data import EnfsiDataset
 from lr_face.losses import TripletLoss
-from lr_face.models import TripletEmbeddingModel, Architecture
+from lr_face.models import Architecture
 from lr_face.utils import fix_tensorflow_rtx
+from lr_face.versioning import Version
 
-# Needed to make TensorFlow 2.x work with RTX Nvidia cards.
 fix_tensorflow_rtx()
 
 
-def finetune(model: TripletEmbeddingModel,
-             anchors: np.ndarray,
-             positives: np.ndarray,
-             negatives: np.ndarray):
-    """
-    Fine-tunes a Tensorflow model.
-
-    Arguments:
-        model: A `TripletEmbeddingModel` instance.
-        anchors: A 4D array containing a batch of anchor images with shape
-            `(batch_size, height, width, num_channels)`.
-        positives: A 4D array containing a batch of images of the same identity
-            as the anchor image with shape `(batch_size, height, width,
-            num_channels)`.
-        negatives: A 4D array containing a batch of images of a different
-            identity than the anchor image with shape `(batch_size, height,
-            width, num_channels)`.
-    """
-
-    model.compile(
-        optimizer=Adam(learning_rate=3e-5),
-        loss=TripletLoss(alpha=.2),  # TODO: better value for alpha?
-    )
-
-    # The triplet loss that is used to train the model actually does not need
-    # any ground truth labels, since it simply aims to maximize the difference
-    # in distances to the anchor embedding between positive and negative query
-    # images. However, Keras' Loss interface still needs a `y_true` that has
-    # the same first dimension as the `y_pred` output by the model. That's why
-    # we create a dummy "ground truth" of the same length.
-    inputs = [anchors, positives, negatives]
-    y = np.zeros(shape=(anchors.shape[0], 1))
-    model.fit(
-        x=inputs,
-        y=y,
-        batch_size=2,  # TODO: make dynamic
-        epochs=100  # TODO: make dynamic
-    )
+def determine_version(version: Optional[str],
+                      architecture: Architecture) -> Version:
+    if version:
+        return Version.from_string(version)
+    else:
+        try:
+            return architecture.get_latest_version().increment()
+        except ValueError:
+            return Version(0, 0, 1)
 
 
-def main(model_name: str, output_dir: str):
-    os.makedirs(output_dir, exist_ok=True)
-    architecture = Architecture[model_name.upper()]
+def main(model_name: str, version: Optional[str] = None):
+    architecture: Architecture = Architecture[model_name.upper()]
+    version = determine_version(version, architecture)
     triplet_embedding_model = architecture.get_triplet_embedding_model()
     dataset = EnfsiDataset(years=[2011, 2012, 2013, 2017])
+    optimizer = Adam(learning_rate=3e-5)
+    loss = TripletLoss(alpha=.2)  # TODO: better value for alpha?
+    batch_size = 2  # TODO: make dynamic
+    num_epochs = 100  # TODO: make dynamic
 
-    anchors, positives, negatives = to_array(
-        dataset.triplets, resolution=architecture.resolution, normalize=True)
     try:
-        finetune(triplet_embedding_model, anchors, positives, negatives)
+        triplet_embedding_model.train(dataset.triplets,
+                                      batch_size,
+                                      num_epochs,
+                                      optimizer,
+                                      loss)
     except KeyboardInterrupt:
-        # Allow user to manually interrupt training and still save checkpoint.
+        # Allow user to manually interrupt training while still saving weights.
         pass
-
-    weights_name = f"{dataset}-{time.strftime('%Y_%m_%d-%H_%M_%S')}"
-    weights_path = os.path.join(output_dir, f'{weights_name}.h5')
-    triplet_embedding_model.save_weights(weights_path, overwrite=True)
+    triplet_embedding_model.save_weights(version)
 
 
 if __name__ == '__main__':
@@ -78,7 +50,7 @@ if __name__ == '__main__':
     Example usage: 
     
     ```
-    python finetuning.py -m vggface -o scratch
+    python finetuning.py -m vggface -v 0.0.1
     ``` 
     """
     parser = argparse.ArgumentParser()
@@ -90,11 +62,12 @@ if __name__ == '__main__':
         help='Should match one of the constants in the `Architecture` Enum'
     )
     parser.add_argument(
-        '--output-dir',
-        '-o',
-        required=True,
+        '--version',
+        '-v',
+        required=False,
+        default=None,
         type=str,
-        help='Path to the directory in which the weights should be stored'
+        help='A new version number. Defaults to the latest version + 1'
     )
     args = parser.parse_args()
     main(**vars(args))

--- a/finetuning.py
+++ b/finetuning.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Optional
 
 from tensorflow.keras.optimizers import Adam
 
@@ -7,25 +6,18 @@ from lr_face.data import EnfsiDataset
 from lr_face.losses import TripletLoss
 from lr_face.models import Architecture
 from lr_face.utils import fix_tensorflow_rtx
-from lr_face.versioning import Version
+from lr_face.versioning import Tag
 
 fix_tensorflow_rtx()
 
 
-def determine_version(version: Optional[str],
-                      architecture: Architecture) -> Version:
-    if version:
-        return Version.from_string(version)
-    else:
-        try:
-            return architecture.get_latest_version().increment()
-        except ValueError:
-            return Version.from_string("0.0.1")
-
-
-def main(model_name: str, version: Optional[str] = None):
-    architecture: Architecture = Architecture[model_name.upper()]
-    version = determine_version(version, architecture)
+def main(architecture: str, tag: str):
+    architecture: Architecture = Architecture[architecture.upper()]
+    try:
+        version = architecture.get_latest_version(tag) + 1
+    except ValueError:
+        version = 1
+    tag = Tag(tag, version)
     triplet_embedding_model = architecture.get_triplet_embedding_model()
     dataset = EnfsiDataset(years=[2011, 2012, 2013, 2017])
     optimizer = Adam(learning_rate=3e-5)
@@ -42,7 +34,7 @@ def main(model_name: str, version: Optional[str] = None):
     except KeyboardInterrupt:
         # Allow user to manually interrupt training while still saving weights.
         pass
-    triplet_embedding_model.save_weights(version)
+    triplet_embedding_model.save_weights(tag)
 
 
 if __name__ == '__main__':
@@ -50,24 +42,23 @@ if __name__ == '__main__':
     Example usage: 
     
     ```
-    python finetuning.py -m vggface -v 0.0.1
+    python finetuning.py -a vggface -t no_augmentation
     ``` 
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--model-name',
-        '-m',
+        '--architecture',
+        '-a',
         required=True,
         type=str,
         help='Should match one of the constants in the `Architecture` Enum'
     )
     parser.add_argument(
-        '--version',
-        '-v',
-        required=False,
-        default=None,
+        '--tag',
+        '-t',
+        required=True,
         type=str,
-        help='A new version number. Defaults to an increment of latest version'
+        help='The name used for saving the finetuned weights'
     )
     args = parser.parse_args()
     main(**vars(args))

--- a/finetuning.py
+++ b/finetuning.py
@@ -20,7 +20,7 @@ def determine_version(version: Optional[str],
         try:
             return architecture.get_latest_version().increment()
         except ValueError:
-            return Version(0, 0, 1)
+            return Version.from_string("0.0.1")
 
 
 def main(model_name: str, version: Optional[str] = None):

--- a/finetuning.py
+++ b/finetuning.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
         required=False,
         default=None,
         type=str,
-        help='A new version number. Defaults to the latest version + 1'
+        help='A new version number. Defaults to an increment of latest version'
     )
     args = parser.parse_args()
     main(**vars(args))

--- a/learning_rate_test.py
+++ b/learning_rate_test.py
@@ -68,7 +68,8 @@ def lr_test(model: TripletEmbeddingModel, triplets: List[FaceTriplet]):
     # Compile the model.
     optimizer = OPTIMIZER(learning_rate=INITIAL_LEARNING_RATE)
     loss = TripletLoss(alpha=FOCAL_LOSS_ALPHA)
-    model.compile(optimizer, loss)
+    trainable_model = model.build_trainable_model()
+    trainable_model.compile(optimizer, loss)
 
     # Create the learning rate scheduler.
     schedule = partial(get_learning_rate,
@@ -83,10 +84,10 @@ def lr_test(model: TripletEmbeddingModel, triplets: List[FaceTriplet]):
         math.log(MAX_LEARNING_RATE / INITIAL_LEARNING_RATE, STEP_SIZE))
 
     # Start training, saving the loss after each "epoch".
-    history = model.fit_generator(generator(),
-                                  steps_per_epoch=1,
-                                  epochs=epochs,
-                                  callbacks=[callback])
+    history = trainable_model.fit_generator(generator(),
+                                            steps_per_epoch=1,
+                                            epochs=epochs,
+                                            callbacks=[callback])
 
     plot_path = f'scratch/learning_rate_test-{DATASET}.jpg'
     plt.plot(list(map(schedule, range(epochs))), history.history['loss'])

--- a/learning_rate_test.py
+++ b/learning_rate_test.py
@@ -96,7 +96,6 @@ def lr_test(model: TripletEmbeddingModel, triplets: List[FaceTriplet]):
     plt.ylabel('Loss')
     plt.savefig(plot_path)
     print(f'Saved plot to {plot_path}')
-    plt.show()
 
 
 def main():

--- a/lr_face/data.py
+++ b/lr_face/data.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import os
 import random
@@ -28,6 +30,9 @@ class FaceImage:
     # A globally unique identifier for the person depicted on the image, only
     # shared with other images that depict the same person.
     identity: str
+
+    # A textual description of where the image came from (optional).
+    source: Optional[str] = None
 
     # An optional miscellaneous dictionary where any potentially relevant
     # metadata about the image can be stored.
@@ -255,9 +260,7 @@ class ForenFaceDataset(Dataset):
         for file in files:
             path = os.path.join(self.RESOURCE_FOLDER, file)
             identity = f'FORENFACE-{file[:3]}'
-            data.append(FaceImage(path, identity, {
-                'source': str(self)
-            }))
+            data.append(FaceImage(path, identity, source=str(self)))
         return data
 
 
@@ -274,9 +277,11 @@ class LfwDataset(Dataset):
                 person_dir = os.path.join(self.RESOURCE_FOLDER, person)
                 for image_file in os.listdir(person_dir):
                     image_path = os.path.join(person_dir, image_file)
-                    data.append(FaceImage(image_path, identity, {
-                        'source': str(self)
-                    }))
+                    data.append(FaceImage(
+                        image_path,
+                        identity,
+                        source=str(self)
+                    ))
         return data
 
     @property
@@ -317,9 +322,7 @@ class LfwDataset(Dataset):
         return FaceImage(
             path=self._get_path(person, idx),
             identity=self._create_identity(person),
-            meta={
-                'source': str(self)
-            }
+            source=str(self)
         )
 
     @staticmethod
@@ -363,19 +366,27 @@ class EnfsiDataset(Dataset):
 
                     # Create a record for the reference image.
                     path = os.path.join(folder, reference)
-                    data.append(FaceImage(path, reference_id, {
-                        'source': str(self),
-                        'year': year,
-                        'idx': idx
-                    }))
+                    data.append(FaceImage(
+                        path,
+                        reference_id,
+                        source=str(self),
+                        meta={
+                            'year': year,
+                            'idx': idx
+                        }
+                    ))
 
                     # Create a record for the query image.
                     path = os.path.join(folder, query)
-                    data.append(FaceImage(path, query_id, {
-                        'source': str(self),
-                        'year': year,
-                        'idx': idx
-                    }))
+                    data.append(FaceImage(
+                        path,
+                        query_id,
+                        source=str(self),
+                        meta={
+                            'year': year,
+                            'idx': idx
+                        }
+                    ))
         return data
 
     @property

--- a/lr_face/data.py
+++ b/lr_face/data.py
@@ -646,7 +646,7 @@ def split_by_identity(
     Takes a `Dataset` or `List[FaceImage]` and splits it into two sub-lists of
     sizes `(1 - test_size)` and `test_size`, respectively, where `test_size`
     is a float representing a fraction of the total size of `data`. The two
-    returned sub-lists are guaranteed to disjoint in terms of the identities
+    returned sub-lists are guaranteed to be disjoint in terms of the identities
     of their images.
 
     :param data: Union[Dataset, List[FaceImage]]

--- a/lr_face/models.py
+++ b/lr_face/models.py
@@ -5,7 +5,7 @@ import importlib
 import os
 import pickle
 from enum import Enum
-from typing import Tuple, List, Optional
+from typing import Tuple, List, Optional, Union
 
 import numpy as np
 import tensorflow as tf
@@ -271,11 +271,13 @@ class Architecture(Enum):
         raise ValueError("Unable to load base model")
 
     def get_embedding_model(self,
-                            version: Optional[Version] = None,
+                            version: Optional[Union[str, Version]] = None,
                             use_triplets: bool = False) -> EmbeddingModel:
         base_model = self.get_base_model()
         os.makedirs(self.model_dir, exist_ok=True)
         cls = TripletEmbeddingModel if use_triplets else EmbeddingModel
+        if isinstance(version, str):
+            version = Version.from_string(version)
         embedding_model = cls(
             base_model,
             version,
@@ -287,7 +289,7 @@ class Architecture(Enum):
 
     def get_triplet_embedding_model(
             self,
-            version: Optional[Version] = None
+            version: Optional[Union[str, Version]] = None
     ) -> TripletEmbeddingModel:
         embedding_model = self.get_embedding_model(version, use_triplets=True)
         if not isinstance(embedding_model, TripletEmbeddingModel):
@@ -296,7 +298,7 @@ class Architecture(Enum):
 
     def get_scorer_model(
             self,
-            version: Optional[Version] = None
+            version: Optional[Union[str, Version]] = None
     ) -> ScorerModel:
         embedding_model = self.get_embedding_model(version, use_triplets=False)
         return ScorerModel(embedding_model)

--- a/lr_face/models.py
+++ b/lr_face/models.py
@@ -109,7 +109,7 @@ class EmbeddingModel:
         if cache_dir:
             output_path = os.path.join(
                 cache_dir,
-                str(self),
+                str(self).replace(':', '-'),  # Windows compatibility
                 image.source or '_',
                 f'{hashlib.md5(image.path.encode()).hexdigest()}.obj'
             )
@@ -174,7 +174,7 @@ class TripletEmbeddingModel(EmbeddingModel):
               num_epochs: int,
               optimizer: tf.keras.optimizers.Optimizer,
               loss: TripletLoss):
-        trainable_model = self._build_trainable_model()
+        trainable_model = self.build_trainable_model()
         trainable_model.compile(optimizer, loss)
         anchors, positives, negatives = to_array(
             triplets,
@@ -196,7 +196,7 @@ class TripletEmbeddingModel(EmbeddingModel):
             epochs=num_epochs
         )
 
-    def _build_trainable_model(self) -> tf.keras.Model:
+    def build_trainable_model(self) -> tf.keras.Model:
         input_shape = (*self.resolution, 3)
         anchors = tf.keras.layers.Input(input_shape)
         positives = tf.keras.layers.Input(input_shape)

--- a/lr_face/utils.py
+++ b/lr_face/utils.py
@@ -1,8 +1,7 @@
 import argparse
 import os
 import re
-from functools import wraps, lru_cache
-from typing import Callable
+from functools import lru_cache
 
 import cv2
 import numpy as np
@@ -12,7 +11,8 @@ from keras.preprocessing import image
 
 def write_output(df, experiment_name):
     # %H:%M:%S -> : (colon) werkt niet in windows
-    output_file = os.path.join('.', 'output', f'{experiment_name}_experiments_results.csv')
+    output_file = os.path.join('.', 'output',
+                               f'{experiment_name}_experiments_results.csv')
     with open(output_file, 'w+') as f:
         df.to_csv(f, header=True)
 
@@ -23,7 +23,8 @@ def parser_setup():
 
     :return: parser (ArgumentParser object)
     """
-    parser = argparse.ArgumentParser(description='Run one or more calibration experiments')
+    parser = argparse.ArgumentParser(
+        description='Run one or more calibration experiments')
 
     parser.add_argument('--data', '-d',
                         help='Select the type or set of data to be used. Codes can be found in' +
@@ -35,10 +36,12 @@ def parser_setup():
                         nargs='+')
     parser.add_argument('--calibrator', '-c',
                         help='Select the calibrator to be used. Codes can be found in \'params.py\',' +
-                             'e.g.: KDE. Defaults to settings in \'current_set_up\'', nargs='+')
+                             'e.g.: KDE. Defaults to settings in \'current_set_up\'',
+                        nargs='+')
     parser.add_argument('--params', '-p',
                         help='Select the parameter set(s) to be used. Codes can be found in \'params.py\',' +
-                             'e.g.: SET1. Defaults to settings in \'current_set_up\'', nargs='+')
+                             'e.g.: SET1. Defaults to settings in \'current_set_up\'',
+                        nargs='+')
     return parser
 
 
@@ -72,7 +75,8 @@ def parse_object_string(obj_string, name_only=False):
                 for par in body_arr:
                     key_val = par.split('=')
                     if len(key_val) == 2:
-                        obj_dict['body'][key_val[0].strip()] = key_val[1].strip()
+                        obj_dict['body'][key_val[0].strip()] = key_val[
+                            1].strip()
                     else:
                         obj_dict['body'][key_val[0].strip()] = None
     return obj_dict
@@ -94,13 +98,15 @@ def process_dataframe(df):
     }
     for new_column, old_column in make_name_columns.items():
         try:
-            df[new_column] = df.apply(lambda row: get_function_names(row[old_column]), axis=1)
+            df[new_column] = df.apply(
+                lambda row: get_function_names(row[old_column]), axis=1)
         except (KeyError, AttributeError):
             df[new_column] = None
 
     # Cast to string columns:
     df['fraction_training'] = round(df['fraction_training'], 1).astype(str)
-    df['train_calibration_same_data'] = df['train_calibration_same_data'].astype(str)
+    df['train_calibration_same_data'] = df[
+        'train_calibration_same_data'].astype(str)
 
     make_parameter_columns = [
         # old column name: parameter name (new column is [old column name]_[parameter name])
@@ -110,7 +116,9 @@ def process_dataframe(df):
     for column, parameter in make_parameter_columns:
         new_column = column + "_" + parameter
         try:
-            df[new_column] = df.apply(lambda row: get_parameter_value(row[column], parameter), axis=1)
+            df[new_column] = df.apply(
+                lambda row: get_parameter_value(row[column], parameter),
+                axis=1)
         except (KeyError, AttributeError):
             df[new_column] = None
 
@@ -120,7 +128,8 @@ def process_dataframe(df):
         'distr': ['h1_name', 'h2_name'],
         'samedata_scorer': ['scorer_name', 'train_calibration_same_data'],
         'weighted_scorer_label': ['scorer_name', 'scorers_class_weight'],
-        'weighted_calibrator_label': ['calibrator_name', 'calibrators_class_weight'],
+        'weighted_calibrator_label': ['calibrator_name',
+                                      'calibrators_class_weight'],
         'weighted': ['scorers_class_weight', 'calibrators_class_weight']
     }
     for new_column, column_list in make_concatenated_columns.items():
@@ -178,15 +187,15 @@ def concat_columns(df, column_names, output_column_name, separator='-'):
 
 
 def resize_and_normalize(img, target_size):
-        right_size_img = cv2.resize(img, target_size)
+    right_size_img = cv2.resize(img, target_size)
 
-        img_pixels = image.img_to_array(right_size_img)
-        img_pixels = np.expand_dims(img_pixels, axis=0)
+    img_pixels = image.img_to_array(right_size_img)
+    img_pixels = np.expand_dims(img_pixels, axis=0)
 
-        # normalize input in [0, 1]
-        img_pixels /= 255
+    # normalize input in [0, 1]
+    img_pixels /= 255
 
-        return img_pixels
+    return img_pixels
 
 
 def fix_tensorflow_rtx():

--- a/lr_face/versioning.py
+++ b/lr_face/versioning.py
@@ -5,13 +5,18 @@ import re
 
 
 class Tag:
-    def __init__(self, name: str, version: int = 0):
-        if ':' in name and not version:
-            name, version = name.split(':')
-            version = int(version)
-
+    def __init__(self, name: str, version: int = None):
         # Convert '-' to '_' for unambiguous filename formats.
-        self.name = name.replace('-', '_')
+        name = name.replace('-', '_')
+
+        if not version:
+            if ':' in name:
+                name, version = name.split(':')
+                version = int(version)
+            else:
+                version = 1
+
+        self.name = name
         self.version = version
 
     @classmethod

--- a/lr_face/versioning.py
+++ b/lr_face/versioning.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import os
 import re
-from dataclasses import dataclass
-from typing import Union
+from typing import Union, Iterator
 
 
-@dataclass(frozen=True)
 class Version:
-    major: int = 0
-    minor: int = 0
-    micro: int = 0
+    def __init__(self, major: Union[str, int], minor: int = 0, micro: int = 0):
+        # If `major` is a `str`, assume it actually holds the full version
+        # number, e.g. "0.1.4", and create a `Version` instance from that.
+        if isinstance(major, str):
+            self.major, self.minor, self.micro = self.from_string(major)
+        else:
+            self.major = major
+            self.minor = minor
+            self.micro = micro
 
     @classmethod
     def from_filename(cls, filename: str) -> Version:
@@ -36,6 +40,23 @@ class Version:
         return f'{basename}{self.suffix}{ext}'
 
     def increment(self, major: bool = False, minor: bool = False) -> Version:
+        """
+        Returns a new `Version` instance with its micro version bumped by 1. If
+        `major` or `minor` is True, the major or minor version is bumped,
+        respectively, instead.
+
+        Examples:
+
+        ```python
+         Version("0.0.1").increment()  # Version("0.0.2")
+         Version("0.1.4").increment()  # Version("0.1.5")
+         Version("1.3.6").increment()  # Version("1.3.7")
+         Version("0.0.1").increment(minor=True)  # Version("0.1.0")
+         Version("0.1.4").increment(minor=True)  # Version("0.2.0")
+         Version("1.3.6").increment(minor=True)  # Version("1.4.0")
+         Version("1.3.6").increment(major=True)  # Version("2.0.0")
+         ```
+        """
         if major and minor:
             raise ValueError(
                 'Cannot increment major and minor version simultaneously')
@@ -76,3 +97,6 @@ class Version:
 
     def __str__(self) -> str:
         return f'{self.major}.{self.minor}.{self.micro}'
+
+    def __iter__(self) -> Iterator[int]:
+        return iter([self.major, self.minor, self.micro])

--- a/lr_face/versioning.py
+++ b/lr_face/versioning.py
@@ -2,136 +2,46 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Union, Iterator
 
 
-class Version:
-    def __init__(self, major: Union[str, int], minor: int = 0, micro: int = 0):
-        """
-        Instantiate a `Version` instance in one of two ways:
-            (1) pass along a full version string as the only argument, e.g.
-                `Version('0.2.6')`, the other two arguments are then ignored;
-            (2) pass along three separate integers for the major, minor and
-                micro versions, e.g. `Version(0, 2, 6)`.
+class Tag:
+    def __init__(self, name: str, version: int = 0):
+        if ':' in name and not version:
+            name, version = name.split(':')
+            version = int(version)
 
-        :param major: Union[str, int]
-        :param minor: int
-        :param micro: int
-        """
-        if isinstance(major, str):
-            self.major, self.minor, self.micro = self.from_string(major)
-        else:
-            self.major = major
-            self.minor = minor
-            self.micro = micro
+        # Convert '-' to '_' for unambiguous filename formats.
+        self.name = name.replace('-', '_')
+        self.version = version
 
     @classmethod
-    def from_filename(cls, filename: str) -> Version:
-        """
-        Takes a filename and extracts the version from it. It assumes the
-        version is at the end of the filename, just before the extension, and
-        separated from the rest of the filename by an underscore.
-
-        Example:
-        ```python
-        Version.from_filename('test_0.2.6.txt')  # Version('0.2.6')
-        ```
-
-        :param filename: str
-        :return: Version
-        """
-        matches = re.search(r'_(\d(?:\.\d+)+)\.\w+$', filename)
+    def from_filename(cls, filename: str) -> Tag:
+        basename, _ = os.path.splitext(filename)
+        matches = re.search(r'-([^-]+)-(\d+)$', basename)
         if matches:
-            return cls.from_string(matches.group(1))
-        raise ValueError(f'Could not deduce version from filename {filename}')
+            name, version = matches.groups()
+            return cls(name, int(version))
+        raise ValueError(f'Could not deduce tag from file {filename}')
 
     @classmethod
-    def from_string(cls, string: str) -> Version:
-        """
-        Takes a version (e.g. "0.2.6") and turns it into a `Version` instance.
-
-        :param string: str
-        :return: Version
-        """
-        matches = re.search(r'^(\d+)(?:\.(\d+))?(?:\.(\d+))?$', string)
-        if matches:
-            major, minor, micro = (int(d or 0) for d in matches.groups())
-            return cls(major, minor, micro)
-        raise ValueError(f'Could not deduce version from string {string}')
+    def get_version_from_filename(cls, filename: str) -> int:
+        return cls.from_filename(filename).version
 
     def append_to_filename(self, filename: str) -> str:
         """
-        Takes a filename and adds the version number to it.
+        Takes a filename and appends this tag to it.
 
         Example:
 
         ```python
-        Version('0.0.1').append_to_filename('test.txt')  # 'test_0.0.1.txt'
+        Tag('tag', 1).append_to_filename('test.txt')  # 'test-tag-1.txt'
         ```
 
         :param filename: str
         :return: str
         """
         basename, ext = os.path.splitext(filename)
-        return f'{basename}_{str(self)}{ext}'
+        return f'{basename}-{self.name}-{self.version}{ext}'
 
-    def increment(self, major: bool = False, minor: bool = False) -> Version:
-        """
-        Returns a new `Version` instance with its micro version bumped by 1. If
-        `major` or `minor` is True, the major or minor version is bumped,
-        respectively, instead.
-
-        Examples:
-
-        ```python
-         Version("0.0.1").increment()  # Version("0.0.2")
-         Version("0.1.4").increment()  # Version("0.1.5")
-         Version("1.3.6").increment()  # Version("1.3.7")
-         Version("0.0.1").increment(minor=True)  # Version("0.1.0")
-         Version("0.1.4").increment(minor=True)  # Version("0.2.0")
-         Version("1.3.6").increment(minor=True)  # Version("1.4.0")
-         Version("1.3.6").increment(major=True)  # Version("2.0.0")
-         ```
-        """
-        if major and minor:
-            raise ValueError('Cannot increment both major and minor version')
-        if major:
-            return Version(self.major + 1, 0, 0)
-        if minor:
-            return Version(self.major, self.minor + 1, 0)
-        return Version(self.major, self.minor, self.micro + 1)
-
-    def __hash__(self) -> int:
-        return hash(str(self))
-
-    def __eq__(self, other: Union[str, Version]) -> bool:
-        if isinstance(other, str):
-            other = Version.from_string(other)
-        return isinstance(other, self.__class__) \
-               and self.major == other.major \
-               and self.minor == other.minor \
-               and self.micro == other.micro
-
-    def __gt__(self, other: Union[str, Version]):
-        if isinstance(other, str):
-            other = self.from_string(other)
-        return self.major > other.major \
-               or (self.major == other.major and self.minor > other.minor) \
-               or (self.major == other.major
-                   and self.minor == other.minor
-                   and self.micro > other.micro)
-
-    def __ge__(self, other: Union[str, Version]):
-        return self > other or self == other
-
-    def __lt__(self, other: Union[str, Version]):
-        return not (self > other or self == other)
-
-    def __le__(self, other: Union[str, Version]):
-        return self < other or self == other
-
-    def __str__(self) -> str:
-        return f'{self.major}.{self.minor}.{self.micro}'
-
-    def __iter__(self) -> Iterator[int]:
-        return iter([self.major, self.minor, self.micro])
+    def __str__(self):
+        return f'{self.name}:{self.version}'

--- a/lr_face/versioning.py
+++ b/lr_face/versioning.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
-from functools import total_ordering
 from typing import Union
 
 
-@total_ordering
 @dataclass(frozen=True)
 class Version:
     major: int = 0
@@ -16,17 +14,16 @@ class Version:
 
     @classmethod
     def from_filename(cls, filename: str) -> Version:
-        matches = re.search(r'_(\d+)\.(\d+)\.(\d+)\.\w+$', filename)
+        matches = re.search(r'_(\d(?:\.\d+)+)\.\w+$', filename)
         if matches:
-            major, minor, micro = map(int, matches.groups())
-            return cls(major, minor, micro)
+            return cls.from_string(matches.group(1))
         raise ValueError(f'Could not deduce version from filename {filename}')
 
     @classmethod
     def from_string(cls, string: str) -> Version:
-        matches = re.search(r'^(\d+)\.(\d+).(\d+)$', string)
+        matches = re.search(r'^(\d+)(?:\.(\d+))?(?:\.(\d+))?$', string)
         if matches:
-            major, minor, micro = map(int, matches.groups())
+            major, minor, micro = (int(d or 0) for d in matches.groups())
             return cls(major, minor, micro)
         raise ValueError(f'Could not deduce version from string {string}')
 
@@ -39,6 +36,9 @@ class Version:
         return f'{basename}{self.suffix}{ext}'
 
     def increment(self, major: bool = False, minor: bool = False) -> Version:
+        if major and minor:
+            raise ValueError(
+                'Cannot increment major and minor version simultaneously')
         if major:
             return Version(self.major + 1, 0, 0)
         if minor:
@@ -48,7 +48,9 @@ class Version:
     def __hash__(self) -> int:
         return hash(str(self))
 
-    def __eq__(self, other: Version) -> bool:
+    def __eq__(self, other: Union[str, Version]) -> bool:
+        if isinstance(other, str):
+            other = Version.from_string(other)
         return isinstance(other, self.__class__) \
                and self.major == other.major \
                and self.minor == other.minor \
@@ -62,6 +64,15 @@ class Version:
                or (self.major == other.major
                    and self.minor == other.minor
                    and self.micro > other.micro)
+
+    def __ge__(self, other: Union[str, Version]):
+        return self > other or self == other
+
+    def __lt__(self, other: Union[str, Version]):
+        return not (self > other or self == other)
+
+    def __le__(self, other: Union[str, Version]):
+        return self < other or self == other
 
     def __str__(self) -> str:
         return f'{self.major}.{self.minor}.{self.micro}'

--- a/lr_face/versioning.py
+++ b/lr_face/versioning.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from functools import total_ordering
+from typing import Union
+
+
+@total_ordering
+@dataclass(frozen=True)
+class Version:
+    major: int = 0
+    minor: int = 0
+    micro: int = 0
+
+    @classmethod
+    def from_filename(cls, filename: str) -> Version:
+        matches = re.search(r'_(\d+)\.(\d+)\.(\d+)\.\w+$', filename)
+        if matches:
+            major, minor, micro = map(int, matches.groups())
+            return cls(major, minor, micro)
+        raise ValueError(f'Could not deduce version from filename {filename}')
+
+    @classmethod
+    def from_string(cls, string: str) -> Version:
+        matches = re.search(r'^(\d+)\.(\d+).(\d+)$', string)
+        if matches:
+            major, minor, micro = map(int, matches.groups())
+            return cls(major, minor, micro)
+        raise ValueError(f'Could not deduce version from string {string}')
+
+    @property
+    def suffix(self) -> str:
+        return f'_{str(self)}'
+
+    def append_to_filename(self, filename: str) -> str:
+        basename, ext = os.path.splitext(filename)
+        return f'{basename}{self.suffix}{ext}'
+
+    def increment(self, major: bool = False, minor: bool = False) -> Version:
+        if major:
+            return Version(self.major + 1, 0, 0)
+        if minor:
+            return Version(self.major, self.minor + 1, 0)
+        return Version(self.major, self.minor, self.micro + 1)
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def __eq__(self, other: Version) -> bool:
+        return isinstance(other, self.__class__) \
+               and self.major == other.major \
+               and self.minor == other.minor \
+               and self.micro == other.micro
+
+    def __gt__(self, other: Union[str, Version]):
+        if isinstance(other, str):
+            other = self.from_string(other)
+        return self.major > other.major \
+               or (self.major == other.major and self.minor > other.minor) \
+               or (self.major == other.major
+                   and self.minor == other.minor
+                   and self.micro > other.micro)
+
+    def __str__(self) -> str:
+        return f'{self.major}.{self.minor}.{self.micro}'

--- a/params.py
+++ b/params.py
@@ -79,10 +79,10 @@ SCORERS = {
                        'fbdeepface'],
     'all': {
         'dummy': DummyScorerModel(),
-        'openface': Architecture.OPENFACE.get_scorer_model(),
-        'facenet': Architecture.FACENET.get_scorer_model(),
-        'fbdeepface': Architecture.FBDEEPFACE.get_scorer_model(),
-        'vggface': Architecture.VGGFACE.get_scorer_model(),
+        'openface': Architecture.OPENFACE.get_scorer_model(version=None),
+        'facenet': Architecture.FACENET.get_scorer_model(version=None),
+        'fbdeepface': Architecture.FBDEEPFACE.get_scorer_model(version=None),
+        'vggface': Architecture.VGGFACE.get_scorer_model(version=None),
     }
 }
 

--- a/params.py
+++ b/params.py
@@ -53,7 +53,7 @@ PARAMS = {
 }
 
 DATA = {
-    'current_set_up': ['lfw'],
+    'current_set_up': ['enfsi'],
     'all': {
         'test': {
             'datasets': [TestDataset()],
@@ -82,11 +82,11 @@ SCORERS = {
                        'fbdeepface'],
     'all': {
         'dummy': DummyScorerModel(),
-        # TODO: specify version to use below.
-        'openface': Architecture.OPENFACE.get_scorer_model(version=None),
-        'facenet': Architecture.FACENET.get_scorer_model(version=None),
-        'fbdeepface': Architecture.FBDEEPFACE.get_scorer_model(version=None),
-        'vggface': Architecture.VGGFACE.get_scorer_model(version=None),
+        # TODO: specify tags to use below.
+        'openface': Architecture.OPENFACE.get_scorer_model(tag=None),
+        'facenet': Architecture.FACENET.get_scorer_model(tag=None),
+        'fbdeepface': Architecture.FBDEEPFACE.get_scorer_model(tag=None),
+        'vggface': Architecture.VGGFACE.get_scorer_model(tag=None),
     }
 }
 
@@ -95,7 +95,7 @@ New calibrators can be added to 'all'.
 For the input of an experiment the 'current_set_up' list can be updated.
 """
 CALIBRATORS = {
-    'current_set_up': ['logit'],
+    'current_set_up': ['KDE'],
     'all': {
         'logit': LogitCalibrator(),
         'logit_normalized': NormalizedCalibrator(LogitCalibrator()),

--- a/params.py
+++ b/params.py
@@ -53,7 +53,7 @@ PARAMS = {
 }
 
 DATA = {
-    'current_set_up': ['enfsi'],
+    'current_set_up': ['lfw'],
     'all': {
         'test': {
             'datasets': [TestDataset()],
@@ -95,7 +95,7 @@ New calibrators can be added to 'all'.
 For the input of an experiment the 'current_set_up' list can be updated.
 """
 CALIBRATORS = {
-    'current_set_up': ['KDE'],
+    'current_set_up': ['logit'],
     'all': {
         'logit': LogitCalibrator(),
         'logit_normalized': NormalizedCalibrator(LogitCalibrator()),

--- a/params.py
+++ b/params.py
@@ -9,6 +9,9 @@ from lir import (LogitCalibrator,
 
 from lr_face.data import TestDataset, EnfsiDataset, LfwDataset
 from lr_face.models import DummyScorerModel, Architecture
+from lr_face.utils import fix_tensorflow_rtx
+
+fix_tensorflow_rtx()
 
 """How often to repeat all experiments"""
 
@@ -79,6 +82,7 @@ SCORERS = {
                        'fbdeepface'],
     'all': {
         'dummy': DummyScorerModel(),
+        # TODO: specify version to use below.
         'openface': Architecture.OPENFACE.get_scorer_model(version=None),
         'facenet': Architecture.FACENET.get_scorer_model(version=None),
         'fbdeepface': Architecture.FBDEEPFACE.get_scorer_model(version=None),

--- a/run.py
+++ b/run.py
@@ -10,11 +10,8 @@ from tqdm import tqdm
 from lr_face.data import FacePair, split_by_identity, make_pairs
 from lr_face.evaluators import evaluate
 from lr_face.experiment_settings import ExperimentSettings
-from lr_face.utils import write_output, parser_setup, process_dataframe, \
-    fix_tensorflow_rtx
+from lr_face.utils import write_output, parser_setup, process_dataframe
 from params import TIMES
-
-fix_tensorflow_rtx()
 
 
 def run(args):

--- a/tests/test_finetuning.py
+++ b/tests/test_finetuning.py
@@ -1,66 +1,110 @@
-import os
+from typing import List
 
 import numpy as np
 import pytest
 import tensorflow as tf
 from tensorflow.keras.optimizers import Adam
 
+from lr_face.data import FaceImage, DummyFaceImage, FacePair, make_pairs, \
+    FaceTriplet, make_triplets
 from lr_face.losses import TripletLoss
-from lr_face.models import TripletEmbeddingModel
-from tests.src.util import scratch_dir
+from lr_face.models import TripletEmbeddingModel, EmbeddingModel
+from lr_face.versioning import Version
+from tests.src.util import scratch_dir, get_tests_path
+
+SCRATCH_DIR = get_tests_path('scratch/finetuning')
 
 
-def get_dummy_embedding_model(batch_input_shape) -> tf.keras.Model:
+def get_dummy_base_model(input_shape) -> tf.keras.Model:
     model = tf.keras.Sequential([
+        tf.keras.layers.Input(shape=input_shape),
         tf.keras.layers.Flatten(),
         tf.keras.layers.Dense(10, activation='relu'),
         tf.keras.layers.Lambda(lambda x: tf.math.l2_normalize(x, axis=-1))
     ])
-    model.build(input_shape=batch_input_shape)
     return model
 
 
-def get_dummy_triplet_embedding_model(embedding_model: tf.keras.Model) -> \
-        TripletEmbeddingModel:
-    triplet_embedding_model = TripletEmbeddingModel(embedding_model)
-    triplet_embedding_model.compile(
-        optimizer=Adam(learning_rate=3e-4),
-        loss=TripletLoss(alpha=0.5, force_normalization=True)
+def get_dummy_embedding_model(
+        base_model: tf.keras.Model,
+        use_triplets: bool = False
+) -> EmbeddingModel:
+    cls = TripletEmbeddingModel if use_triplets else EmbeddingModel
+    return cls(
+        base_model,
+        version=None,
+        resolution=base_model.input_shape[1:3],
+        model_dir=SCRATCH_DIR,
+        name='DUMMY-TRIPLET-EMBEDDING-MODEL'
     )
-    return triplet_embedding_model
+
+
+def get_dummy_triplet_embedding_model(
+        base_model: tf.keras.Model
+) -> TripletEmbeddingModel:
+    embedding_model = get_dummy_embedding_model(base_model, use_triplets=True)
+    if not isinstance(embedding_model, TripletEmbeddingModel):
+        raise ValueError(
+            f'Expected `TripletEmbeddingModel` instance, '
+            f'but got {type(embedding_model)}'
+        )
+    return embedding_model
 
 
 @pytest.fixture()
 def scratch():
-    yield from scratch_dir('scratch/finetuning')
+    yield from scratch_dir(SCRATCH_DIR)
 
 
-def test_can_load_weights_from_training_model_into_embedding_model(scratch):
-    """
-    This methods tests whether or not it is possible to save the weights of a
-    TripletEmbeddingModel and restore them into an embedding model.
+@pytest.fixture
+def dummy_images() -> List[FaceImage]:
+    ids = [1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5]
+    return [DummyFaceImage(path='', identity=f'TEST-{idx}') for idx in ids]
 
-    """
+
+@pytest.fixture
+def dummy_pairs() -> List[FacePair]:
+    ids = [1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5]
+    images = [DummyFaceImage(path='', identity=f'TEST-{idx}') for idx in ids]
+    return make_pairs(images)
+
+
+@pytest.fixture
+def dummy_triplets() -> List[FaceTriplet]:
+    ids = [1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5]
+    images = [DummyFaceImage(path='', identity=f'TEST-{idx}') for idx in ids]
+    return make_triplets(images)
+
+
+def test_can_load_weights_from_training_model_into_embedding_model(
+        dummy_triplets,
+        scratch
+):
+    input_shape = (10, 10, 3)
+    base_model = get_dummy_base_model(input_shape)
+    triplet_embedding_model = get_dummy_triplet_embedding_model(base_model)
+
+    dummy_image = dummy_triplets[0].anchor
+    y_original = triplet_embedding_model.embed(dummy_image)
+
     batch_size = 1
-    batch_input_shape = (batch_size, 10, 10, 3)
-    embedding_model = get_dummy_embedding_model(batch_input_shape)
-    triplet_embedding_model = get_dummy_triplet_embedding_model(embedding_model)
-    x = [np.random.normal(size=(batch_size, 10, 10, 3)),
-         np.random.normal(size=(batch_size, 10, 10, 3)),
-         np.random.normal(size=(batch_size, 10, 10, 3))]
-    triplet_embedding_model.fit(x=x,
-                         y=np.zeros(shape=(batch_size,)),
-                         batch_size=batch_size,
-                         epochs=1,
-                         verbose=0)
-    weights_path = os.path.join(scratch, 'weights.h5')
-    triplet_embedding_model.save_weights(weights_path)
+    num_epochs = 1
+    optimizer = Adam(learning_rate=3e-4)
+    loss = TripletLoss(alpha=0.5, force_normalization=True)
+    triplet_embedding_model.train(
+        dummy_triplets,
+        batch_size,
+        num_epochs,
+        optimizer,
+        loss
+    )
 
-    y1 = embedding_model.predict(x[0])
+    version = Version(0, 0, 1)
+    triplet_embedding_model.save_weights(version)
+    y_trained = triplet_embedding_model.embed(dummy_image)
 
-    # Reload a blank embedding model and see if we can load our weights into it
-    embedding_model = get_dummy_embedding_model(batch_input_shape)
-    embedding_model.load_weights(weights_path)
-    y2 = embedding_model.predict(x[0])
-
-    assert np.all(y1 == y2)
+    embedding_model = get_dummy_embedding_model(base_model)
+    embedding_model.load_weights(version)
+    y_restored = embedding_model.embed(dummy_image)
+    assert not np.all(y_original == y_trained)
+    assert np.all(y_trained == y_restored)

--- a/tests/test_finetuning.py
+++ b/tests/test_finetuning.py
@@ -9,7 +9,7 @@ from lr_face.data import FaceImage, DummyFaceImage, FacePair, make_pairs, \
     FaceTriplet, make_triplets
 from lr_face.losses import TripletLoss
 from lr_face.models import TripletEmbeddingModel, EmbeddingModel
-from lr_face.versioning import Version
+from lr_face.versioning import Tag
 from tests.src.util import scratch_dir, get_tests_path
 
 SCRATCH_DIR = get_tests_path('scratch/finetuning')
@@ -32,7 +32,7 @@ def get_dummy_embedding_model(
     cls = TripletEmbeddingModel if use_triplets else EmbeddingModel
     return cls(
         base_model,
-        version=None,
+        tag=None,
         resolution=base_model.input_shape[1:3],
         model_dir=SCRATCH_DIR,
         name='DUMMY-TRIPLET-EMBEDDING-MODEL'
@@ -99,12 +99,12 @@ def test_can_load_weights_from_training_model_into_embedding_model(
         loss
     )
 
-    version = Version(0, 0, 1)
-    triplet_embedding_model.save_weights(version)
+    tag = Tag('tag:1')
+    triplet_embedding_model.save_weights(tag)
     y_trained = triplet_embedding_model.embed(dummy_image)
 
     embedding_model = get_dummy_embedding_model(base_model)
-    embedding_model.load_weights(version)
+    embedding_model.load_weights(tag)
     y_restored = embedding_model.embed(dummy_image)
     assert not np.all(y_original == y_trained)
     assert np.all(y_trained == y_restored)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,11 +52,13 @@ def test_get_vggface_embedding_is_deterministic(dummy_images, scratch):
 
 def test_get_vggface_embedding_with_filesystem_caching(dummy_images, scratch):
     dummy_image = dummy_images[0]
+    dummy_image.source = 'test'
     architecture = Architecture.VGGFACE
     embedding_model = architecture.get_embedding_model()
     cache_path = os.path.join(
         scratch,
         str(embedding_model),
+        dummy_image.source,
         f'{hashlib.md5(dummy_image.path.encode()).hexdigest()}.obj'
     )
     assert not os.path.exists(cache_path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,67 @@
+import hashlib
+import os
+import pickle
+from typing import List
+
+import cv2
+import pytest
+
+from lr_face.data import FaceImage, DummyFaceImage
+from lr_face.models import Architecture
+from lr_face.utils import fix_tensorflow_rtx
+from tests.src.util import scratch_dir
+
+fix_tensorflow_rtx()
+
+
+@pytest.fixture
+def dummy_images() -> List[FaceImage]:
+    ids = [1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5]
+    return [DummyFaceImage(path='', identity=f'TEST-{idx}') for idx in ids]
+
+
+@pytest.fixture()
+def scratch():
+    yield from scratch_dir('scratch/test_models')
+
+
+def test_get_vggface_embedding(dummy_images):
+    architecture = Architecture.VGGFACE
+    embedding_model = architecture.get_embedding_model()
+    embedding = embedding_model.embed(dummy_images[0])
+    assert embedding.shape == (architecture.embedding_size,)
+
+
+def test_get_vggface_embedding_is_deterministic(dummy_images, scratch):
+    architecture = Architecture.VGGFACE
+    embedding_model = architecture.get_embedding_model()
+    image = dummy_images[0].get_image()
+    embeddings = []
+
+    # By saving and reloading the FaceImage 3 times with a different file name
+    # we make sure to bypass any caching mechanisms.
+    for i in range(3):
+        image_path = os.path.join(scratch, f'tmp_{i}.jpg')
+        cv2.imwrite(image_path, image)
+        face_image = FaceImage(image_path, dummy_images[0].identity)
+        embeddings.append(embedding_model.embed(face_image))
+
+    assert all(embeddings[0] == embeddings[1])
+    assert all(embeddings[0] == embeddings[2])
+
+
+def test_get_vggface_embedding_with_filesystem_caching(dummy_images, scratch):
+    dummy_image = dummy_images[0]
+    architecture = Architecture.VGGFACE
+    embedding_model = architecture.get_embedding_model()
+    cache_path = os.path.join(
+        scratch,
+        str(embedding_model),
+        f'{hashlib.md5(dummy_image.path.encode()).hexdigest()}.obj'
+    )
+    assert not os.path.exists(cache_path)
+    embedding = embedding_model.embed(dummy_image, cache_dir=scratch)
+    assert os.path.exists(cache_path)
+    with open(cache_path, 'rb') as f:
+        cached_embedding = pickle.load(f)
+    assert all(embedding == cached_embedding)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,6 +65,7 @@ def test_cache_with_class_methods():
         should initially be 0 and then be increased to 1 the first time it is
         called. Subsequent calls should not increment the counter any further.
         """
+
         def __init__(self, bias):
             self.counter: Dict[Tuple[float, float], int] = defaultdict(int)
             self.bias = bias

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lr_face.versioning import Version
 
 
@@ -13,6 +15,20 @@ def test_version_from_string():
     assert version.major == 7
     assert version.minor == 5
     assert version.micro == 1
+
+
+def test_version_from_string_only_major():
+    version = Version.from_string("7")
+    assert version.major == 7
+    assert version.minor == 0
+    assert version.micro == 0
+
+
+def test_version_from_string_only_major_and_minor():
+    version = Version.from_string("7.1")
+    assert version.major == 7
+    assert version.minor == 1
+    assert version.micro == 0
 
 
 def test_version_comparison_equal():
@@ -47,6 +63,21 @@ def test_version_comparison_micro_greater_than():
     assert a < b
 
 
+def test_version_comparison_greater_than_string():
+    assert Version(7, 5, 2) > "7.5.1"
+    assert Version(7, 5, 2) > "7.5"
+
+
+def test_version_comparison_greater_than_or_equal():
+    assert Version(7, 5, 2) >= "7.5.2"
+    assert Version(7, 5, 2) >= "7.5.1"
+
+
+def test_version_comparison_less_than_or_equal():
+    assert Version(7, 5, 2) <= "7.5.2"
+    assert Version(7, 5, 2) <= "7.5.3"
+
+
 def test_get_latest_version():
     versions = [Version(7, 5, 2),
                 Version(1, 6, 9),
@@ -56,3 +87,27 @@ def test_get_latest_version():
                 Version(0, 0, 1)]
 
     assert max(versions) == versions[2]
+
+
+def test_increment_micro():
+    version = Version(7, 5, 1)
+    incremented_version = version.increment()
+    assert incremented_version == Version(7, 5, 2)
+
+
+def test_increment_minor():
+    version = Version(7, 5, 1)
+    incremented_version = version.increment(minor=True)
+    assert incremented_version == Version(7, 6, 0)
+
+
+def test_increment_major():
+    version = Version(7, 5, 1)
+    incremented_version = version.increment(major=True)
+    assert incremented_version == Version(8, 0, 0)
+
+
+def test_increment_major_and_micro():
+    version = Version(7, 5, 1)
+    with pytest.raises(ValueError):
+        version.increment(major=True, minor=True)

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,120 +1,33 @@
 import pytest
 
-from lr_face.versioning import Version
+from lr_face.versioning import Tag
 
 
-def test_version_from_filename():
-    version = Version.from_filename("file_7.5.1.jpg")
-    assert version.major == 7
-    assert version.minor == 5
-    assert version.micro == 1
+def test_create_tag_from_string():
+    tag = Tag('tag:1')
+    assert tag.name == 'tag'
+    assert tag.version == 1
 
 
-def test_version_from_string_constructor():
-    version = Version("7.5.1")
-    assert version.major == 7
-    assert version.minor == 5
-    assert version.micro == 1
-
-
-def test_version_from_string():
-    version = Version.from_string("7.5.1")
-    assert version.major == 7
-    assert version.minor == 5
-    assert version.micro == 1
-
-
-def test_version_from_string_only_major():
-    version = Version.from_string("7")
-    assert version.major == 7
-    assert version.minor == 0
-    assert version.micro == 0
-
-
-def test_version_from_string_only_major_and_minor():
-    version = Version.from_string("7.1")
-    assert version.major == 7
-    assert version.minor == 1
-    assert version.micro == 0
-
-
-def test_version_comparison_equal():
-    a = Version(7, 5, 1)
-    b = Version(7, 5, 1)
-    assert a == b
-
-
-def test_version_comparison_major_greater_than():
-    a = Version(8, 0, 0)
-    b = Version(7, 5, 1)
-    assert a > b
-
-
-def test_version_comparison_minor_greater_than():
-    a = Version(7, 6, 0)
-    b = Version(7, 5, 1)
-    assert a > b
-
-    a = Version(6, 6, 0)
-    b = Version(7, 5, 1)
-    assert a < b
-
-
-def test_version_comparison_micro_greater_than():
-    a = Version(7, 5, 2)
-    b = Version(7, 5, 1)
-    assert a > b
-
-    a = Version(7, 4, 9)
-    b = Version(7, 5, 1)
-    assert a < b
-
-
-def test_version_comparison_greater_than_string():
-    assert Version(7, 5, 2) > "7.5.1"
-    assert Version(7, 5, 2) > "7.5"
-
-
-def test_version_comparison_greater_than_or_equal():
-    assert Version(7, 5, 2) >= "7.5.2"
-    assert Version(7, 5, 2) >= "7.5.1"
-
-
-def test_version_comparison_less_than_or_equal():
-    assert Version(7, 5, 2) <= "7.5.2"
-    assert Version(7, 5, 2) <= "7.5.3"
-
-
-def test_get_latest_version():
-    versions = [Version(7, 5, 2),
-                Version(1, 6, 9),
-                Version(7, 8, 0),
-                Version(6, 8, 3),
-                Version(7, 2, 10),
-                Version(0, 0, 1)]
-
-    assert max(versions) == versions[2]
-
-
-def test_increment_micro():
-    version = Version(7, 5, 1)
-    incremented_version = version.increment()
-    assert incremented_version == Version(7, 5, 2)
-
-
-def test_increment_minor():
-    version = Version(7, 5, 1)
-    incremented_version = version.increment(minor=True)
-    assert incremented_version == Version(7, 6, 0)
-
-
-def test_increment_major():
-    version = Version(7, 5, 1)
-    incremented_version = version.increment(major=True)
-    assert incremented_version == Version(8, 0, 0)
-
-
-def test_increment_major_and_micro():
-    version = Version(7, 5, 1)
+def test_create_tag_from_string_double_colon():
     with pytest.raises(ValueError):
-        version.increment(major=True, minor=True)
+        Tag('tag:2:1')
+
+
+def test_get_version_from_filename():
+    filename = 'myfile-mytag-2.txt'
+    assert Tag.get_version_from_filename(filename) == 2
+
+
+def test_get_tag_from_filename():
+    filename = 'myfile-mytag_simple-2.txt'
+    tag = Tag.from_filename(filename)
+    assert tag.name == 'mytag_simple'
+    assert tag.version == 2
+
+
+def test_append_to_filename():
+    filename = 'myfile.txt'
+    tag = Tag('mytag_simple', 2)
+    tagged_filename = tag.append_to_filename(filename)
+    assert tagged_filename == 'myfile-mytag_simple-2.txt'

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -10,6 +10,13 @@ def test_version_from_filename():
     assert version.micro == 1
 
 
+def test_version_from_string_constructor():
+    version = Version("7.5.1")
+    assert version.major == 7
+    assert version.minor == 5
+    assert version.micro == 1
+
+
 def test_version_from_string():
     version = Version.from_string("7.5.1")
     assert version.major == 7

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,58 @@
+from lr_face.versioning import Version
+
+
+def test_version_from_filename():
+    version = Version.from_filename("file_7.5.1.jpg")
+    assert version.major == 7
+    assert version.minor == 5
+    assert version.micro == 1
+
+
+def test_version_from_string():
+    version = Version.from_string("7.5.1")
+    assert version.major == 7
+    assert version.minor == 5
+    assert version.micro == 1
+
+
+def test_version_comparison_equal():
+    a = Version(7, 5, 1)
+    b = Version(7, 5, 1)
+    assert a == b
+
+
+def test_version_comparison_major_greater_than():
+    a = Version(8, 0, 0)
+    b = Version(7, 5, 1)
+    assert a > b
+
+
+def test_version_comparison_minor_greater_than():
+    a = Version(7, 6, 0)
+    b = Version(7, 5, 1)
+    assert a > b
+
+    a = Version(6, 6, 0)
+    b = Version(7, 5, 1)
+    assert a < b
+
+
+def test_version_comparison_micro_greater_than():
+    a = Version(7, 5, 2)
+    b = Version(7, 5, 1)
+    assert a > b
+
+    a = Version(7, 4, 9)
+    b = Version(7, 5, 1)
+    assert a < b
+
+
+def test_get_latest_version():
+    versions = [Version(7, 5, 2),
+                Version(1, 6, 9),
+                Version(7, 8, 0),
+                Version(6, 8, 3),
+                Version(7, 2, 10),
+                Version(0, 0, 1)]
+
+    assert max(versions) == versions[2]


### PR DESCRIPTION
* Added versioning to models
  - When finetuning a model with `finetuning.py` the weights are stored with a tag name and version number (just a regular `int`). The name is something you specify yourself, the version is incremented automatically from the previous version (starting at 1)
  - `Architecture.get_embedding_model()`, `Architecture.get_triplet_embedding_model()` and `Architecture.get_scorer_model()` now all accept a tag (in the form of either a string such as "mytag:2" or a `Tag` object) which causes the weights for that specific tag to be loaded. If omitted, only the base model weights are loaded (i.e. no finetuning will have taken place)
* Moved `FaceImage.get_embedding()` to `EmbeddingModel.embed()`, which makes more sense and cleans up the code
* Refactored the `TripletEmbeddingModel` so that it is now a subclass of the new class `EmbeddingModel`. These classes abstract away the underlying training procedure used by Keras, so that you don't have to worry about that. This greatly simplified the code for the `TripletEmbeddingModel` class and the `finetuning.py` pipeline
* Added and updated unit tests