### PR TITLE
Remove caching of models

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,0 @@
-from lr_face.models import Architecture
-from lr_face.utils import cache
-
-# When running our tests, cache the models to prevent OOM errors.
-Architecture.get_model = cache(Architecture.get_model)

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+from lr_face.models import Architecture
+from lr_face.utils import cache
+
+# When running our tests, cache the models to prevent OOM errors.
+Architecture.get_model = cache(Architecture.get_model)

--- a/finetuning.py
+++ b/finetuning.py
@@ -26,13 +26,15 @@ def augmenter(image):
 def main(architecture: str, tag: str):
     architecture: Architecture = Architecture[architecture.upper()]
     triplet_embedding_model = architecture.get_triplet_embedding_model()
+    tag = Tag(tag)
 
-    # Determine under which tag to save the fine-tuned weights.
-    try:
-        version = architecture.get_latest_version(tag) + 1
-    except ValueError:
-        version = 1
-    tag = Tag(tag, version)
+    # Determine under which tag to save the fine-tuned weights if none was
+    # explicitly specified.
+    if not tag.version:
+        try:
+            tag.version = architecture.get_latest_version(tag) + 1
+        except ValueError:
+            tag.version = 1
 
     try:
         triplet_embedding_model.train(DATASET.triplets,

--- a/lr_face/models.py
+++ b/lr_face/models.py
@@ -13,7 +13,7 @@ from typing import Tuple, List, Optional, Union
 import numpy as np
 import tensorflow as tf
 from scipy import spatial
-from tensorflow.python.keras.layers import Flatten, Dense, Input
+from tensorflow.python.keras.layers import Flatten, Dense, Input, Lambda
 
 from lr_face.data import FaceImage, FacePair, FaceTriplet, to_array, Augmenter
 from lr_face.losses import TripletLoss
@@ -31,7 +31,12 @@ class DummyModel(tf.keras.Sequential):
     """
 
     def __init__(self):
-        super().__init__([Input(shape=(100, 100, 3)), Flatten(), Dense(100)])
+        super().__init__([
+            Input(shape=(100, 100, 3)),
+            Flatten(),
+            Dense(100),
+            Lambda(lambda x: tf.math.l2_normalize(x, axis=1))
+        ])
 
 
 class ScorerModel:
@@ -102,14 +107,20 @@ class EmbeddingModel:
         :param cache_dir: Optional[str]
         :return: np.ndarray
         """
+        args = locals()
         x = image.get_image(self.resolution, normalize=True)
         x = np.expand_dims(x, axis=0)
+
         if cache_dir:
+            cache_id = '_'.join([
+                hashlib.md5(image.path.encode()).hexdigest(),
+                str(hash(tuple(args)))
+            ])
             output_path = os.path.join(
                 cache_dir,
                 str(self).replace(':', '-'),  # Windows compatibility
                 image.source or '_',
-                f'{hashlib.md5(image.path.encode()).hexdigest()}.obj'
+                f'{cache_id}.obj'
             )
 
             # If the embedding has been cached before, load and return it.
@@ -255,7 +266,6 @@ class Architecture(Enum):
     OPENFACE = 'OpenFace'
     ARCFACE = 'ArcFace'
 
-    @cache
     def get_model(self):
         # TODO: unify cases
         if self.source == 'deepface':

--- a/lr_face/models.py
+++ b/lr_face/models.py
@@ -119,7 +119,8 @@ class EmbeddingModel:
                 cache_dir,
                 str(self).replace(':', '-'),  # Windows compatibility
                 image.source or '_',
-                f'{md5(image.path)}_{md5("".join(map(str, kwargs.values())))}'
+                md5(image.path),
+                f'{md5("".join(map(str, kwargs.values())))}.obj'
             )
 
             # If the embedding has been cached before, load and return it.

--- a/lr_face/models.py
+++ b/lr_face/models.py
@@ -107,15 +107,13 @@ class EmbeddingModel:
         :param cache_dir: Optional[str]
         :return: np.ndarray
         """
-        args = locals()
+        kwargs = locals()
         x = image.get_image(self.resolution, normalize=True)
         x = np.expand_dims(x, axis=0)
 
         if cache_dir:
-            cache_id = '_'.join([
-                hashlib.md5(image.path.encode()).hexdigest(),
-                str(hash(tuple(args)))
-            ])
+            cache_id = hashlib.md5(
+                str(map(hash, kwargs.values())).encode()).hexdigest()
             output_path = os.path.join(
                 cache_dir,
                 str(self).replace(':', '-'),  # Windows compatibility

--- a/lr_face/models.py
+++ b/lr_face/models.py
@@ -8,7 +8,7 @@ import pickle
 import random
 import re
 from enum import Enum
-from typing import Tuple, List, Optional, Union
+from typing import Tuple, List, Optional, Union, Any
 
 import numpy as np
 import tensorflow as tf
@@ -112,13 +112,15 @@ class EmbeddingModel:
         x = np.expand_dims(x, axis=0)
 
         if cache_dir:
-            cache_id = hashlib.md5(
-                str(map(hash, kwargs.values())).encode()).hexdigest()
+            def md5(text: str) -> str:
+                return hashlib.md5(text.encode()).hexdigest()
+
+            cache_id = md5(''.join(map(str, kwargs.values())))
             output_path = os.path.join(
                 cache_dir,
                 str(self).replace(':', '-'),  # Windows compatibility
                 image.source or '_',
-                f'{cache_id}.obj'
+                f'{md5(image.path)}_{cache_id}.obj'
             )
 
             # If the embedding has been cached before, load and return it.

--- a/lr_face/models.py
+++ b/lr_face/models.py
@@ -8,7 +8,7 @@ import pickle
 import random
 import re
 from enum import Enum
-from typing import Tuple, List, Optional, Union, Any
+from typing import Tuple, List, Optional, Union
 
 import numpy as np
 import tensorflow as tf
@@ -115,12 +115,11 @@ class EmbeddingModel:
             def md5(text: str) -> str:
                 return hashlib.md5(text.encode()).hexdigest()
 
-            cache_id = md5(''.join(map(str, kwargs.values())))
             output_path = os.path.join(
                 cache_dir,
                 str(self).replace(':', '-'),  # Windows compatibility
                 image.source or '_',
-                f'{md5(image.path)}_{cache_id}.obj'
+                f'{md5(image.path)}_{md5("".join(map(str, kwargs.values())))}'
             )
 
             # If the embedding has been cached before, load and return it.

--- a/params.py
+++ b/params.py
@@ -56,7 +56,7 @@ PARAMS = {
 }
 
 DATA = {
-    'current_set_up': ['enfsi'],
+    'current_set_up': ['lfw_sanity_check'],
     'all': {
         # Either specify a single dataset as `datasets`, in which case the
         # dataset is split into calibration and test pairs according to the
@@ -101,6 +101,10 @@ DATA = {
             'datasets': (LfwDevDataset(True), LfwDevDataset(False)),
             'fraction_test': None  # Can be omitted if `datasets` is a tuple.
         },
+        'lfw_enfsi': {
+            'datasets': (LfwDevDataset(True), EnfsiDataset(years=[2011, 2012, 2013, 2017])),
+            'fraction_test': None  # Can be omitted if `datasets` is a tuple.
+        },
         'forenface': {
             'datasets': ForenFaceDataset(),
             'fraction_test': .5,
@@ -114,7 +118,7 @@ For the input of an experiment the 'current_set_up' list can be updated.
 """
 
 SCORERS = {
-    'current_set_up': ['dummy'],
+    'current_set_up': ['vggface'],
     'all': {
         # We apply lazy loading to the scorer models since they take up a lot
         # of memory. Each setup has type `Tuple[Architecture, Optional[str]]`.
@@ -127,7 +131,7 @@ SCORERS = {
         'fbdeepface': (Architecture.FBDEEPFACE, None),
         'vggface': (Architecture.VGGFACE, None),
         'arcface': (Architecture.ARCFACE, None),
-        'lfw_sanity_check': (Architecture.VGGFACE, 'lfw_resized_50')
+        'vggface_lfw_resized': (Architecture.VGGFACE, 'lfw_resized'),
     }
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import pytest
+
+from lr_face.models import Architecture
+from lr_face.utils import cache
+
+# When running our tests, cache the models to prevent OOM errors.
+Architecture.get_model = cache(Architecture.get_model)
+
+
+def skip_on_github(func):
+    return pytest.mark.skipif(
+        str(Path.home()) == '/home/runner',
+        reason="Fails on Github because model weights don't exist"
+    )(func)

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -1,19 +1,10 @@
-from pathlib import Path
-
 import numpy as np
-import pytest
 
 from lr_face.models import Architecture
 from lr_face.utils import fix_tensorflow_rtx
+from tests.conftest import skip_on_github
 
 fix_tensorflow_rtx()
-
-
-def skip_on_github(func):
-    return pytest.mark.skipif(
-        str(Path.home()) == '/home/runner',
-        reason="Fails on Github because model weights don't exist"
-    )(func)
 
 
 @skip_on_github

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -2,9 +2,11 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import tensorflow as tf
 
 from lr_face.models import Architecture
+from lr_face.utils import fix_tensorflow_rtx
+
+fix_tensorflow_rtx()
 
 
 def skip_on_github(func):
@@ -24,7 +26,7 @@ def test_get_embedding_models():
         architecture.get_embedding_model()
 
 
-@pytest.mark.skip(reason="Not all embedding models have been normalized yet")
+@skip_on_github
 def test_embedding_models_return_normalized_embeddings():
     """
     Tests whether the embedding model of each `Architecture` returns embeddings

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,6 @@
 import hashlib
 import os
 import pickle
-from pathlib import Path
 from typing import List
 
 import cv2
@@ -60,11 +59,16 @@ def test_get_vggface_embedding_with_filesystem_caching(dummy_images, scratch):
     dummy_image.source = 'test'
     architecture = Architecture.VGGFACE
     embedding_model = architecture.get_embedding_model()
+
+    def md5(text: str) -> str:
+        return hashlib.md5(text.encode()).hexdigest()
+
     cache_path = os.path.join(
         scratch,
         str(embedding_model),
         dummy_image.source,
-        f'{hashlib.md5(dummy_image.path.encode()).hexdigest()}.obj'
+        md5(dummy_image.path),
+        f'{md5(f"{str(embedding_model)}{str(dummy_image)}{str(scratch)}")}.obj'
     )
     assert not os.path.exists(cache_path)
     embedding = embedding_model.embed(dummy_image, cache_dir=scratch)


### PR DESCRIPTION
* Removed caching of models, which leads to bugs when different models of the same architecture are instantiated
* This also fixes the issue that was reported in: https://github.com/HolmesNL/forensische-gezichtsvergelijking/pull/41
* Caching is still enabled for tests because otherwise tests just take too long or you get OOM errors (see `conftest.py`)
* Fixed a small bug in versioning of `finetuning.py`
* Added a `cache_id` to `EmbeddingModel.embed()` so that if arguments are added to this method in the future, the resulting cache files on the filesystem will automatically generate unique filenames for all possible combinations of those arguments' values